### PR TITLE
Fix crash on ending background activity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ osx_image: xcode7.3
 install:
   - carthage bootstrap --platform iOS
 
+branches:
+   only:
+     - develop
+    - master
+    
+
 script:
   - set -o pipefail
   - xcodebuild clean build test -scheme Transport-ios -destination 'platform=iOS Simulator,name=iPhone 6s,OS=9.3' | xcpretty -s

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 branches:
    only:
      - develop
-    - master
+     - master
     
 
 script:

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
-github "wireapp/ocmock" "v3.2.2"
-github "wireapp/wire-ios-utilities" "10.30.2"
-github "wireapp/wire-ios-testing" "6.31.4"
+github "wireapp/ocmock" "v2.2.4-wire"
 github "wireapp/wire-ios-system" "14.40.3"
+github "wireapp/wire-ios-utilities" "10.30.2"
+github "wireapp/wire-ios-testing" "6.31.6"

--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -21,7 +21,7 @@ private var _instance : BackgroundActivityFactory? = BackgroundActivityFactory()
 
 @objc public class BackgroundActivityFactory: NSObject {
     
-    public var mainGroupQueue : ZMSGroupQueue?
+    public var mainGroupQueue : ZMSGroupQueue? = nil
     
     @objc public class func sharedInstance() -> BackgroundActivityFactory
     {
@@ -35,13 +35,6 @@ private var _instance : BackgroundActivityFactory? = BackgroundActivityFactory()
     {
         _instance = nil
     }
-    
-    override init()
-    {
-        self.mainGroupQueue = nil
-        super.init()
-    }
-
     
     @objc public func backgroundActivity(withName name: String) -> ZMBackgroundActivity?
     {

--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -1,9 +1,19 @@
 //
-//  BackgroundActivityFactory.swift
-//  ZMTransport
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
 //
-//  Created by Florian Morel on 7/27/16.
-//  Copyright © 2016 Wire. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 
@@ -13,7 +23,7 @@ private var _instance : BackgroundActivityFactory? = BackgroundActivityFactory()
     
     public var mainGroupQueue : ZMSGroupQueue?
     
-    @objc public class func instance() -> BackgroundActivityFactory
+    @objc public class func sharedInstance() -> BackgroundActivityFactory
     {
         if _instance == nil {
             _instance = BackgroundActivityFactory()

--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -1,0 +1,48 @@
+//
+//  BackgroundActivityFactory.swift
+//  ZMTransport
+//
+//  Created by Florian Morel on 7/27/16.
+//  Copyright © 2016 Wire. All rights reserved.
+//
+
+
+private var _instance : BackgroundActivityFactory? = BackgroundActivityFactory() // swift automatically dispatch_once make this thread safe
+
+@objc public class BackgroundActivityFactory: NSObject {
+    
+    public var mainGroupQueue : ZMSGroupQueue?
+    
+    @objc public class func instance() -> BackgroundActivityFactory
+    {
+        if _instance == nil {
+            _instance = BackgroundActivityFactory()
+        }
+        return _instance!
+    }
+    
+    @objc public class func tearDownInstance()
+    {
+        _instance = nil
+    }
+    
+    override init()
+    {
+        self.mainGroupQueue = nil
+        super.init()
+    }
+
+    
+    @objc public func backgroundActivity(withName name: String) -> ZMBackgroundActivity?
+    {
+        guard let mainGroupQueue = mainGroupQueue else { return nil }
+        return ZMBackgroundActivity.beginBackgroundActivityWithName(name, groupQueue: mainGroupQueue)
+    }
+    
+    @objc public func backgroundActibity(withName name: String, expirationHandler handler:(Void -> Void)) -> ZMBackgroundActivity?
+    {
+        guard let mainGroupQueue = mainGroupQueue else { return nil }
+        return ZMBackgroundActivity.beginBackgroundActivityWithName(name, groupQueue: mainGroupQueue, expirationHandler: handler)
+    }
+    
+}

--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -49,7 +49,7 @@ private var _instance : BackgroundActivityFactory? = BackgroundActivityFactory()
         return ZMBackgroundActivity.beginBackgroundActivityWithName(name, groupQueue: mainGroupQueue)
     }
     
-    @objc public func backgroundActibity(withName name: String, expirationHandler handler:(Void -> Void)) -> ZMBackgroundActivity?
+    @objc public func backgroundActivity(withName name: String, expirationHandler handler:(Void -> Void)) -> ZMBackgroundActivity?
     {
         guard let mainGroupQueue = mainGroupQueue else { return nil }
         return ZMBackgroundActivity.beginBackgroundActivityWithName(name, groupQueue: mainGroupQueue, expirationHandler: handler)

--- a/Source/Background/ZMSessionCancelTimer.m
+++ b/Source/Background/ZMSessionCancelTimer.m
@@ -57,7 +57,7 @@ ZM_EMPTY_ASSERTING_INIT();
 
 - (void)start;
 {
-    self.activity = [[BackgroundActivityFactory instance] backgroundActivityWithName:NSStringFromClass(self.class)];
+    self.activity = [[BackgroundActivityFactory sharedInstance] backgroundActivityWithName:NSStringFromClass(self.class)];
     [self.timer fireAfterTimeInterval:self.timeout];
 }
 

--- a/Source/Background/ZMSessionCancelTimer.m
+++ b/Source/Background/ZMSessionCancelTimer.m
@@ -20,6 +20,8 @@
 @import ZMCSystem;
 @import ZMUtilities;
 
+#import <ZMTransport/ZMTransport-Swift.h>
+
 #import "ZMSessionCancelTimer.h"
 #import "ZMURLSession.h"
 #import "ZMBackgroundActivity.h"
@@ -55,7 +57,7 @@ ZM_EMPTY_ASSERTING_INIT();
 
 - (void)start;
 {
-    self.activity = [ZMBackgroundActivity beginBackgroundActivityWithName:NSStringFromClass(self.class)];
+    self.activity = [[BackgroundActivityFactory instance] backgroundActivityWithName:NSStringFromClass(self.class)];
     [self.timer fireAfterTimeInterval:self.timeout];
 }
 

--- a/Source/Public/ZMBackgroundActivity.h
+++ b/Source/Public/ZMBackgroundActivity.h
@@ -19,16 +19,20 @@
 
 #import <Foundation/Foundation.h>
 
-
+@protocol ZMSGroupQueue;
 
 // thin wrapper around [UIApplication beginBackgroundTaskWithName:expirationHandler:]
 @interface ZMBackgroundActivity : NSObject
 
-+ (instancetype)beginBackgroundActivityWithName:(NSString *)taskName;
++ (instancetype)beginBackgroundActivityWithName:(NSString *)taskName groupQueue:(id<ZMSGroupQueue>)groupQueue;
 
 + (instancetype)beginBackgroundActivityWithName:(NSString *)taskName
+                                     groupQueue:(id<ZMSGroupQueue>)groupQueue
                               expirationHandler:(void (^)(void))handler;
 
+/**
+ *  This switches to the groupQueue to end the activity.
+ */
 - (void)endActivity;
 
 @end

--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -75,7 +75,7 @@ extern NSString * const ZMTransportSessionShouldKeepWebsocketOpenKey;
 @property (nonatomic, readonly) ZMPersistentCookieStorage *cookieStorage;
 @property (nonatomic) NSString *clientID;
 
-- (instancetype)initWithBaseURL:(NSURL *)baseURL websocketURL:(NSURL *)websocketURL keyValueStore:(id<ZMKeyValueStore>)keyValueStore;
+- (instancetype)initWithBaseURL:(NSURL *)baseURL websocketURL:(NSURL *)websocketURL keyValueStore:(id<ZMKeyValueStore>)keyValueStore mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue;
 
 - (void)tearDown;
 

--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -22,6 +22,8 @@
 @import ImageIO;
 @import MobileCoreServices;
 
+#import <ZMTransport/ZMTransport-Swift.h>
+
 #import "ZMTransportRequest+Internal.h"
 #import "ZMTransportData.h"
 #import "ZMTransportResponse.h"
@@ -475,7 +477,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 {
     ZMTaskIdentifier *taskIdentifier = [ZMTaskIdentifier identifierWithIdentifier:identifier sessionIdentifier:sessionIdentifier];
     NSString *label = [NSString stringWithFormat:@"Task created handler of REQ %@ %@ -> %@ ", self.methodAsString, self.path, taskIdentifier];
-    ZMBackgroundActivity *creationActivity = [ZMBackgroundActivity beginBackgroundActivityWithName:NSStringFromSelector(_cmd)];
+    ZMBackgroundActivity *creationActivity = [[BackgroundActivityFactory instance ] backgroundActivityWithName:NSStringFromSelector(_cmd)];
     ZMSDispatchGroup *handlerGroup = [ZMSDispatchGroup groupWithLabel:@"ZMTransportRequest task creation handler"];
     
     for (ZMTaskCreatedHandler *handler in self.taskCreatedHandlers) {
@@ -521,7 +523,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 {
     response.startOfUploadTimestamp = self.startOfUploadTimestamp;
 
-    ZMBackgroundActivity *completeActivity = [ZMBackgroundActivity beginBackgroundActivityWithName:NSStringFromSelector(_cmd)];
+    ZMBackgroundActivity *completeActivity = [[BackgroundActivityFactory instance] backgroundActivityWithName:NSStringFromSelector(_cmd)];
     ZMSDispatchGroup *group = response.dispatchGroup;
     ZMSDispatchGroup *group2 = [ZMSDispatchGroup groupWithLabel:@"ZMTransportRequest"];
     [group2 enter];

--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -477,7 +477,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 {
     ZMTaskIdentifier *taskIdentifier = [ZMTaskIdentifier identifierWithIdentifier:identifier sessionIdentifier:sessionIdentifier];
     NSString *label = [NSString stringWithFormat:@"Task created handler of REQ %@ %@ -> %@ ", self.methodAsString, self.path, taskIdentifier];
-    ZMBackgroundActivity *creationActivity = [[BackgroundActivityFactory instance ] backgroundActivityWithName:NSStringFromSelector(_cmd)];
+    ZMBackgroundActivity *creationActivity = [[BackgroundActivityFactory sharedInstance] backgroundActivityWithName:NSStringFromSelector(_cmd)];
     ZMSDispatchGroup *handlerGroup = [ZMSDispatchGroup groupWithLabel:@"ZMTransportRequest task creation handler"];
     
     for (ZMTaskCreatedHandler *handler in self.taskCreatedHandlers) {
@@ -523,7 +523,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 {
     response.startOfUploadTimestamp = self.startOfUploadTimestamp;
 
-    ZMBackgroundActivity *completeActivity = [[BackgroundActivityFactory instance] backgroundActivityWithName:NSStringFromSelector(_cmd)];
+    ZMBackgroundActivity *completeActivity = [[BackgroundActivityFactory sharedInstance] backgroundActivityWithName:NSStringFromSelector(_cmd)];
     ZMSDispatchGroup *group = response.dispatchGroup;
     ZMSDispatchGroup *group2 = [ZMSDispatchGroup groupWithLabel:@"ZMTransportRequest"];
     [group2 enter];

--- a/Source/TransportSession/ZMTransportSession+internal.h
+++ b/Source/TransportSession/ZMTransportSession+internal.h
@@ -42,7 +42,8 @@
                                  baseURL:(NSURL *)baseURL
                             websocketURL:(NSURL *)websocketURL
                         pushChannelClass:(Class)pushChannelClass
-                           keyValueStore:(id<ZMKeyValueStore>)keyValueStore NS_DESIGNATED_INITIALIZER;
+                           keyValueStore:(id<ZMKeyValueStore>)keyValueStore
+                          mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue NS_DESIGNATED_INITIALIZER;
 
 - (NSURLSessionTask *)suspendedTaskForRequest:(ZMTransportRequest *)request onSession:(ZMURLSession *)session;
 

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -21,6 +21,8 @@
 @import ZMUtilities;
 @import UIKit;
 
+#import <ZMTransport/ZMTransport-Swift.h>
+
 #import "ZMTransportSession+Internal.h"
 #import "ZMTransportCodec.h"
 #import "ZMAccessToken.h"
@@ -114,7 +116,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 - (instancetype)init
 {
     @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"You should not use -init" userInfo:nil];
-    return [self initWithBaseURL:nil websocketURL:nil keyValueStore:nil];
+    return [self initWithBaseURL:nil websocketURL:nil keyValueStore:nil mainGroupQueue:nil];
 }
 
 + (void)setUpConfiguration:(NSURLSessionConfiguration *)configuration;
@@ -168,7 +170,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     return configuration;
 }
 
-- (instancetype)initWithBaseURL:(NSURL *)baseURL websocketURL:(NSURL *)websocketURL keyValueStore:(id<ZMKeyValueStore>)keyValueStore;
+- (instancetype)initWithBaseURL:(NSURL *)baseURL websocketURL:(NSURL *)websocketURL keyValueStore:(id<ZMKeyValueStore>)keyValueStore mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue;
 {
     NSOperationQueue *queue = [NSOperationQueue zm_serialQueueWithName:@"ZMTransportSession"];
     ZMSDispatchGroup *group = [ZMSDispatchGroup groupWithLabel:@"ZMTransportSession init"];
@@ -192,7 +194,8 @@ static NSInteger const DefaultMaximumRequests = 6;
                                     group:group
                                   baseURL:baseURL
                              websocketURL:websocketURL
-                            keyValueStore:keyValueStore];
+                            keyValueStore:keyValueStore
+                           mainGroupQueue:mainGroupQueue];
 }
 
 - (instancetype)initWithURLSessionSwitch:(ZMURLSessionSwitch *)URLSessionSwitch
@@ -203,6 +206,7 @@ static NSInteger const DefaultMaximumRequests = 6;
                                  baseURL:(NSURL *)baseURL
                             websocketURL:(NSURL *)websocketURL
                            keyValueStore:(id<ZMKeyValueStore>)keyValueStore
+                          mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue;
 {
     return [self initWithURLSessionSwitch:URLSessionSwitch
                          requestScheduler:requestScheduler
@@ -212,7 +216,8 @@ static NSInteger const DefaultMaximumRequests = 6;
                                   baseURL:baseURL
                              websocketURL:websocketURL
                          pushChannelClass:nil
-                            keyValueStore:keyValueStore];
+                            keyValueStore:keyValueStore
+                           mainGroupQueue:mainGroupQueue];
 }
 
 
@@ -224,12 +229,15 @@ static NSInteger const DefaultMaximumRequests = 6;
                                  baseURL:(NSURL *)baseURL
                             websocketURL:(NSURL *)websocketURL
                         pushChannelClass:(Class)pushChannelClass
-                           keyValueStore:(id<ZMKeyValueStore>)keyValueStore;
+                           keyValueStore:(id<ZMKeyValueStore>)keyValueStore
+                          mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue;
 {
     self = [super init];
     if (self) {
         self.baseURL = baseURL;
         self.websocketURL = websocketURL;
+        [[BackgroundActivityFactory instance] setMainGroupQueue:mainGroupQueue];
+        
         self.workQueue = queue;
         _workGroup = group;
         self.cookieStorage = [ZMPersistentCookieStorage storageForServerName:baseURL.host];
@@ -558,7 +566,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 - (void)enterBackground;
 {
-    ZMBackgroundActivity *enterActivity = [ZMBackgroundActivity beginBackgroundActivityWithName:@"ZMTransportSession.enterBackground"];
+    ZMBackgroundActivity *enterActivity = [[BackgroundActivityFactory instance] backgroundActivityWithName:@"ZMTransportSession.enterBackground"];
     ZMLogInfo(@"<%@: %p> %@", self.class, self, NSStringFromSelector(_cmd));
     NSOperationQueue *queue = self.workQueue;
     ZMSDispatchGroup *group = self.workGroup;
@@ -598,7 +606,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 - (void)prepareForSuspendedState;
 {
-    ZMBackgroundActivity *activity = [ZMBackgroundActivity beginBackgroundActivityWithName:@"enqueue access token"];
+    ZMBackgroundActivity *activity = [[BackgroundActivityFactory instance] backgroundActivityWithName:@"enqueue access token"];
     [self.urlSessionSwitch.currentSession countTasksWithCompletionHandler:^(NSUInteger count) {
         if (0 < count) {
             [self sendAccessTokenRequest];

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -236,7 +236,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     if (self) {
         self.baseURL = baseURL;
         self.websocketURL = websocketURL;
-        [[BackgroundActivityFactory instance] setMainGroupQueue:mainGroupQueue];
+        [[BackgroundActivityFactory sharedInstance] setMainGroupQueue:mainGroupQueue];
         
         self.workQueue = queue;
         _workGroup = group;
@@ -566,7 +566,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 - (void)enterBackground;
 {
-    ZMBackgroundActivity *enterActivity = [[BackgroundActivityFactory instance] backgroundActivityWithName:@"ZMTransportSession.enterBackground"];
+    ZMBackgroundActivity *enterActivity = [[BackgroundActivityFactory sharedInstance] backgroundActivityWithName:@"ZMTransportSession.enterBackground"];
     ZMLogInfo(@"<%@: %p> %@", self.class, self, NSStringFromSelector(_cmd));
     NSOperationQueue *queue = self.workQueue;
     ZMSDispatchGroup *group = self.workGroup;
@@ -606,7 +606,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 - (void)prepareForSuspendedState;
 {
-    ZMBackgroundActivity *activity = [[BackgroundActivityFactory instance] backgroundActivityWithName:@"enqueue access token"];
+    ZMBackgroundActivity *activity = [[BackgroundActivityFactory sharedInstance] backgroundActivityWithName:@"enqueue access token"];
     [self.urlSessionSwitch.currentSession countTasksWithCompletionHandler:^(NSUInteger count) {
         if (0 < count) {
             [self sendAccessTokenRequest];

--- a/Tests/Source/Background/ZMBackgroundActivityTests.m
+++ b/Tests/Source/Background/ZMBackgroundActivityTests.m
@@ -1,0 +1,65 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+@import XCTest;
+@import ZMTesting;
+@import OCMock;
+
+#import "ZMBackgroundActivity.h"
+
+@interface ZMBackgroundActivityTests : ZMTBaseTest
+
+
+@end
+
+@implementation ZMBackgroundActivityTests
+
+- (void)setUp;
+{
+    [super setUp];
+}
+
+- (void)tearDown;
+{
+    [super tearDown];
+}
+
+- (void)testThatBackgroundActivityEndItsActivityInTheGivenGroupQueue;
+{
+    // given
+    id mockGroupQueue = [OCMockObject mockForProtocol:@protocol(ZMSGroupQueue)];
+    
+    id mockApplication = [OCMockObject niceMockForClass:UIApplication.class];
+    [[[[mockApplication stub] andReturn:mockApplication] classMethod] sharedApplication];
+    
+    ZMBackgroundActivity *activity = [ZMBackgroundActivity beginBackgroundActivityWithName:@"JCVD" groupQueue:mockGroupQueue];
+    
+    // expect
+    [[mockGroupQueue expect] performGroupedBlock:OCMOCK_ANY];
+    
+    //when
+    [activity endActivity];
+    
+    //then
+    [mockGroupQueue verify];
+    
+    [mockGroupQueue stopMocking];
+    [mockApplication stopMocking];
+}
+
+@end

--- a/Tests/Source/Background/ZMSessionCancelTimerTests.m
+++ b/Tests/Source/Background/ZMSessionCancelTimerTests.m
@@ -21,6 +21,7 @@
 @import ZMTesting;
 @import OCMock;
 
+#import <ZMTransport/ZMTransport-Swift.h>
 #import "ZMSessionCancelTimer.h"
 #import "ZMURLSession.h"
 #import "ZMBackgroundActivity.h"
@@ -116,20 +117,21 @@
 - (void)testThatItBeginsABackgroundActivityWhenStarting
 {
     // given
-    ZMBackgroundActivity *backgroundActivity = [OCMockObject mockForClass:ZMBackgroundActivity.class];
+    BackgroundActivityFactory *backgroundActivityFactory = [OCMockObject mockForClass:BackgroundActivityFactory.class];
     
     ZMURLSession *session = [OCMockObject mockForClass:ZMURLSession.class];
     ZMSessionCancelTimer *sut = [[ZMSessionCancelTimer alloc] initWithURLSession:session timeout:1.0];
     
     // expect
-    [[[(OCMockObject *)backgroundActivity expect] classMethod] beginBackgroundActivityWithName:OCMOCK_ANY];
+    [[(OCMockObject *)backgroundActivityFactory expect] backgroundActivityWithName:OCMOCK_ANY];
+    [[[[(OCMockObject *)backgroundActivityFactory expect] classMethod] andReturn:backgroundActivityFactory] instance];
     
     // when
     [sut start];
     
     // then
-    [(OCMockObject *)backgroundActivity verify];
-    [(OCMockObject *)backgroundActivity stopMocking];
+    [(OCMockObject *)backgroundActivityFactory verify];
+    [(OCMockObject *)backgroundActivityFactory stopMocking];
 }
 
 - (void)testThatitEndsTheBackgroundActivityWhenItIsCancelled;
@@ -142,8 +144,8 @@
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"cancel was called"];
     
+    
     id activity = [OCMockObject mockForClass:ZMBackgroundActivity.class];
-    [[[activity stub] andReturn:activity] beginBackgroundActivityWithName:[OCMArg any]];
     
     // expectations
     [[session stub] cancelAllTasksWithCompletionHandler:[OCMArg checkWithBlock:^BOOL(dispatch_block_t block) {
@@ -155,7 +157,10 @@
         [expectation fulfill];
     }] endActivity];
     
-    
+    id factory = [OCMockObject mockForClass:BackgroundActivityFactory.class];
+    [[[[factory stub] andReturn:factory] classMethod] instance];
+    [[[factory stub] andReturn:activity] backgroundActivityWithName:OCMOCK_ANY];
+
     // when
     [sut start];
     [sut cancel];
@@ -163,6 +168,7 @@
     
     // then
     [activity stopMocking];
+    [factory stopMocking];
 }
 
 - (void)testThatItEndsABackgroundActivityWhenTheTimerFires
@@ -176,7 +182,6 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"cancel was called"];
     
     id activity = [OCMockObject mockForClass:ZMBackgroundActivity.class];
-    [[[activity stub] andReturn:activity] beginBackgroundActivityWithName:[OCMArg any]];
     
     // expectations
     [[session stub] cancelAllTasksWithCompletionHandler:[OCMArg checkWithBlock:^BOOL(dispatch_block_t block) {
@@ -188,6 +193,10 @@
         [expectation fulfill];
     }] endActivity];
 
+    id factory = [OCMockObject mockForClass:BackgroundActivityFactory.class];
+    [[[[factory stub] andReturn:factory] classMethod] instance];
+    [[[factory stub] andReturn:activity] backgroundActivityWithName:OCMOCK_ANY];
+
     
     // when
     [sut start];
@@ -195,6 +204,7 @@
     
     // then
     [activity stopMocking];
+    [factory stopMocking];
 }
 
 @end

--- a/Tests/Source/Background/ZMSessionCancelTimerTests.m
+++ b/Tests/Source/Background/ZMSessionCancelTimerTests.m
@@ -124,7 +124,7 @@
     
     // expect
     [[(OCMockObject *)backgroundActivityFactory expect] backgroundActivityWithName:OCMOCK_ANY];
-    [[[[(OCMockObject *)backgroundActivityFactory expect] classMethod] andReturn:backgroundActivityFactory] instance];
+    [[[[(OCMockObject *)backgroundActivityFactory expect] classMethod] andReturn:backgroundActivityFactory] sharedInstance];
     
     // when
     [sut start];
@@ -158,7 +158,7 @@
     }] endActivity];
     
     id factory = [OCMockObject mockForClass:BackgroundActivityFactory.class];
-    [[[[factory stub] andReturn:factory] classMethod] instance];
+    [[[[factory stub] andReturn:factory] classMethod] sharedInstance];
     [[[factory stub] andReturn:activity] backgroundActivityWithName:OCMOCK_ANY];
 
     // when
@@ -194,7 +194,7 @@
     }] endActivity];
 
     id factory = [OCMockObject mockForClass:BackgroundActivityFactory.class];
-    [[[[factory stub] andReturn:factory] classMethod] instance];
+    [[[[factory stub] andReturn:factory] classMethod] sharedInstance];
     [[[factory stub] andReturn:activity] backgroundActivityWithName:OCMOCK_ANY];
 
     

--- a/Tests/Source/TransportSession/ZMTransportRequestSchedulerTests.m
+++ b/Tests/Source/TransportSession/ZMTransportRequestSchedulerTests.m
@@ -1051,10 +1051,16 @@
         // when
         self.sut.schedulerState = ZMTransportRequestSchedulerStateRateLimitedHoldingOff;
         
-        NSDate *high = [NSDate dateWithTimeIntervalSinceNow:1.15 * 2. * interval];
+        double const upperRandomAdjustment = 2.0;   // this is the max of the range of possible value
+        double const upperBackoffAdjustment = 1.15; // this is set to a value above the possible range in the test case
+        
+        // we create a date that is above to the limit mode time to ensure it switches time
+        NSDate *high = [NSDate dateWithTimeIntervalSinceNow:upperBackoffAdjustment * upperRandomAdjustment * interval];
         
         // then
-        [self spinMainQueueWithTimeout: 0.8 * 0.5 * interval];
+        
+        // backoffAdjustement * randrom adjustment * interval
+        [self spinMainQueueWithTimeout: 0.5 * 0.5 * interval];
         XCTAssertNotEqual(self.sut.schedulerState, ZMTransportRequestSchedulerStateRateLimitedRetrying, @"Iteration: %d", i);
         XCTAssertTrue([self waitUntilDate:high verificationBlock:^BOOL{
             return (self.sut.schedulerState == ZMTransportRequestSchedulerStateRateLimitedRetrying);

--- a/Tests/Source/TransportSession/ZMTransportRequestSchedulerTests.m
+++ b/Tests/Source/TransportSession/ZMTransportRequestSchedulerTests.m
@@ -1045,7 +1045,7 @@
     // We'll run this a few times, since the time interval is randomly shifted, and we want to try a few outcomes:
     for (int i = 0; i < 7; ++i) {
         // given
-        NSTimeInterval const interval = 0.05;
+        NSTimeInterval const interval = 0.10;
         self.sut.timeUntilRetryModeWhenRateLimited = interval;
         
         // when

--- a/Tests/Source/TransportSession/ZMTransportRequestSchedulerTests.m
+++ b/Tests/Source/TransportSession/ZMTransportRequestSchedulerTests.m
@@ -1045,7 +1045,7 @@
     // We'll run this a few times, since the time interval is randomly shifted, and we want to try a few outcomes:
     for (int i = 0; i < 7; ++i) {
         // given
-        NSTimeInterval const interval = 0.10;
+        NSTimeInterval const interval = 0.05;
         self.sut.timeUntilRetryModeWhenRateLimited = interval;
         
         // when

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -288,6 +288,25 @@ static FakePushChannel *currentFakePushChannel;
 }
 @end
 
+#pragma mark - ZMSGroupQueue
+
+@interface FakeGroupQueue : NSObject <ZMSGroupQueue>
+
+@end
+
+@implementation FakeGroupQueue
+
+- (void)performGroupedBlock:(dispatch_block_t)block
+{
+    block();
+}
+
+- (ZMSDispatchGroup *)dispatchGroup
+{
+    return nil;
+}
+
+@end
 //////////////////////////////////////////////////
 //
 #pragma mark - Reachability
@@ -435,7 +454,8 @@ static __weak FakeReachability *currentReachability;
                 baseURL:self.baseURL
                 websocketURL:self.webSocketURL
                 pushChannelClass:FakePushChannel.class
-                keyValueStore:[[FakeKeyValueStore alloc] init]];
+                keyValueStore:[[FakeKeyValueStore alloc] init]
+                mainGroupQueue:[[FakeGroupQueue alloc] init]];
     __weak id weakSelf = self;
     [self.sut setAccessTokenRenewalFailureHandler:^(ZMTransportResponse *response) {
         id strongSelf = weakSelf;
@@ -557,7 +577,8 @@ static __weak FakeReachability *currentReachability;
                 baseURL:url
                 websocketURL:url2
                 pushChannelClass:nil
-                keyValueStore:[[FakeKeyValueStore alloc] init]];
+                keyValueStore:[[FakeKeyValueStore alloc] init]
+                mainGroupQueue:[[FakeGroupQueue alloc] init]];
     
     self.sut.accessToken = self.validAccessToken;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
@@ -765,15 +786,16 @@ static __weak FakeReachability *currentReachability;
 
     ZMURLSessionSwitch *urlSwitch = [[ZMURLSessionSwitch alloc] initWithForegroundSession:foregroundSession backgroundSession:backgroundSession voipSession:voipSession];
     ZMTransportSession *sut = [[ZMTransportSession alloc]
-                initWithURLSessionSwitch:urlSwitch
-                requestScheduler:(id) self.scheduler
-                reachabilityClass:[FakeReachability class]
-                queue:self.queue
-                group:self.dispatchGroup
-                baseURL:url
-                websocketURL:url
-                pushChannelClass:nil
-                keyValueStore:[[FakeKeyValueStore alloc] init]];
+                               initWithURLSessionSwitch:urlSwitch
+                               requestScheduler:(id) self.scheduler
+                               reachabilityClass:[FakeReachability class]
+                               queue:self.queue
+                               group:self.dispatchGroup
+                               baseURL:url
+                               websocketURL:url
+                               pushChannelClass:nil
+                               keyValueStore:[[FakeKeyValueStore alloc] init]
+                               mainGroupQueue:[[FakeGroupQueue alloc] init]];
     
     sut.accessToken = self.validAccessToken;
     id<ZMTransportData> payload = @{@"numbers": @[@4, @8, @15, @16, @23, @42]};
@@ -811,7 +833,8 @@ static __weak FakeReachability *currentReachability;
                                baseURL:url
                                websocketURL:url
                                pushChannelClass:nil
-                               keyValueStore:[[FakeKeyValueStore alloc] init]];
+                               keyValueStore:[[FakeKeyValueStore alloc] init]
+                               mainGroupQueue:nil];
     
     sut.accessToken = self.validAccessToken;
     id<ZMTransportData> payload = @{@"numbers": @[@4, @8, @15, @16, @23, @42]};

--- a/ZMTransport.xcodeproj/project.pbxproj
+++ b/ZMTransport.xcodeproj/project.pbxproj
@@ -144,6 +144,7 @@
 		BF453F1E1CC63C4800403E1C /* ZMTaskIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = BF453F1C1CC63C4800403E1C /* ZMTaskIdentifier.m */; };
 		BFC6403C1D2CFE3300886274 /* ZMTransportRequest+AssetGet.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC6403B1D2CFE3300886274 /* ZMTransportRequest+AssetGet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFEC39671CC6423700591F36 /* ZMTaskIdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BFEC39661CC6423700591F36 /* ZMTaskIdentifierTests.m */; };
+		CE3677691D48B4BA00A8015A /* BackgroundActivityFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3677681D48B4BA00A8015A /* BackgroundActivityFactory.swift */; };
 		F9331C671CB3D47E00139ECC /* ZMUpdateEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F9331C661CB3D47E00139ECC /* ZMUpdateEventTests.m */; };
 		F9C4317E1CD7ADF300A8542F /* ZMKeychainTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F9C4317D1CD7ADF300A8542F /* ZMKeychainTests.m */; };
 		F9C9A77D1CAE9A240039E10C /* ZMUpdateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = F9C9A77B1CAE9A240039E10C /* ZMUpdateEvent.m */; };
@@ -353,6 +354,7 @@
 		BF453F1C1CC63C4800403E1C /* ZMTaskIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMTaskIdentifier.m; sourceTree = "<group>"; };
 		BFC6403B1D2CFE3300886274 /* ZMTransportRequest+AssetGet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMTransportRequest+AssetGet.h"; sourceTree = "<group>"; };
 		BFEC39661CC6423700591F36 /* ZMTaskIdentifierTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMTaskIdentifierTests.m; sourceTree = "<group>"; };
+		CE3677681D48B4BA00A8015A /* BackgroundActivityFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundActivityFactory.swift; sourceTree = "<group>"; };
 		F9331C661CB3D47E00139ECC /* ZMUpdateEventTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMUpdateEventTests.m; sourceTree = "<group>"; };
 		F9C4317D1CD7ADF300A8542F /* ZMKeychainTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMKeychainTests.m; sourceTree = "<group>"; };
 		F9C9A77B1CAE9A240039E10C /* ZMUpdateEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMUpdateEvent.m; sourceTree = "<group>"; };
@@ -698,6 +700,7 @@
 				54CA15051B32F2C1008D3787 /* ZMSessionCancelTimer.m */,
 				54CA15061B32F2C1008D3787 /* ZMTemporaryFileListForBackgroundRequests.h */,
 				54CA15071B32F2C1008D3787 /* ZMTemporaryFileListForBackgroundRequests.m */,
+				CE3677681D48B4BA00A8015A /* BackgroundActivityFactory.swift */,
 			);
 			path = Background;
 			sourceTree = "<group>";
@@ -1049,6 +1052,7 @@
 				5499FFDE1B31C66D00835C8B /* ZMWebSocketHandshake.m in Sources */,
 				54CA15DC1B32F54B008D3787 /* TransportTracingProbes.d in Sources */,
 				54CA15B91B32F2C1008D3787 /* ZMTransportResponse.m in Sources */,
+				CE3677691D48B4BA00A8015A /* BackgroundActivityFactory.swift in Sources */,
 				095840201B9591F1004555F9 /* NSData+Multipart.m in Sources */,
 				54CA15551B32F2C1008D3787 /* ZMPersistentCookieStorage.m in Sources */,
 				54CA15531B32F2C1008D3787 /* ZMAccessTokenHandler.m in Sources */,
@@ -1238,10 +1242,14 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 09F027D81B721EBE00BADDB6 /* ZMTransport-ios.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/ZMTransport-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wire.$(PRODUCT_NAME:rfc1034identifier)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
 		};
@@ -1249,9 +1257,12 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 09F027D81B721EBE00BADDB6 /* ZMTransport-ios.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Resources/ZMTransport-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.wire.$(PRODUCT_NAME:rfc1034identifier)";
 			};
 			name = Release;

--- a/ZMTransport.xcodeproj/project.pbxproj
+++ b/ZMTransport.xcodeproj/project.pbxproj
@@ -145,6 +145,7 @@
 		BFC6403C1D2CFE3300886274 /* ZMTransportRequest+AssetGet.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC6403B1D2CFE3300886274 /* ZMTransportRequest+AssetGet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFEC39671CC6423700591F36 /* ZMTaskIdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BFEC39661CC6423700591F36 /* ZMTaskIdentifierTests.m */; };
 		CE3677691D48B4BA00A8015A /* BackgroundActivityFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3677681D48B4BA00A8015A /* BackgroundActivityFactory.swift */; };
+		CEABB5E01D4B864D00C94BC1 /* ZMBackgroundActivityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = CEABB5DF1D4B864D00C94BC1 /* ZMBackgroundActivityTests.m */; };
 		F9331C671CB3D47E00139ECC /* ZMUpdateEventTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F9331C661CB3D47E00139ECC /* ZMUpdateEventTests.m */; };
 		F9C4317E1CD7ADF300A8542F /* ZMKeychainTests.m in Sources */ = {isa = PBXBuildFile; fileRef = F9C4317D1CD7ADF300A8542F /* ZMKeychainTests.m */; };
 		F9C9A77D1CAE9A240039E10C /* ZMUpdateEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = F9C9A77B1CAE9A240039E10C /* ZMUpdateEvent.m */; };
@@ -355,6 +356,7 @@
 		BFC6403B1D2CFE3300886274 /* ZMTransportRequest+AssetGet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMTransportRequest+AssetGet.h"; sourceTree = "<group>"; };
 		BFEC39661CC6423700591F36 /* ZMTaskIdentifierTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMTaskIdentifierTests.m; sourceTree = "<group>"; };
 		CE3677681D48B4BA00A8015A /* BackgroundActivityFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundActivityFactory.swift; sourceTree = "<group>"; };
+		CEABB5DF1D4B864D00C94BC1 /* ZMBackgroundActivityTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMBackgroundActivityTests.m; sourceTree = "<group>"; };
 		F9331C661CB3D47E00139ECC /* ZMUpdateEventTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMUpdateEventTests.m; sourceTree = "<group>"; };
 		F9C4317D1CD7ADF300A8542F /* ZMKeychainTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMKeychainTests.m; sourceTree = "<group>"; };
 		F9C9A77B1CAE9A240039E10C /* ZMUpdateEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMUpdateEvent.m; sourceTree = "<group>"; };
@@ -547,6 +549,7 @@
 			children = (
 				546E89C41B33015000DD1042 /* ZMSessionCancelTimerTests.m */,
 				546E89C51B33015000DD1042 /* ZMTemporaryFileListForBackgroundRequestTests.m */,
+				CEABB5DF1D4B864D00C94BC1 /* ZMBackgroundActivityTests.m */,
 			);
 			path = Background;
 			sourceTree = "<group>";
@@ -1071,6 +1074,7 @@
 				546E89F11B33015000DD1042 /* ZMWebSocketHandshakeTests.m in Sources */,
 				0928E2051BA023A30057232E /* NSData_MultipartTests.m in Sources */,
 				09A2188E1B79E56B0076547A /* ZMSessionCancelTimerTests.m in Sources */,
+				CEABB5E01D4B864D00C94BC1 /* ZMBackgroundActivityTests.m in Sources */,
 				546E89F51B33015000DD1042 /* ZMExponentialBackoffTests.m in Sources */,
 				09A218A11B79F1050076547A /* ZMBackendEnvironmentTests.m in Sources */,
 				546E89F71B33015000DD1042 /* ZMTaskIdentifierMapTests.m in Sources */,


### PR DESCRIPTION
`ZMBackgroundActivity` is making use of `UIApplication` shared instance, which isn't thread safe and crash the application in some cases.

This PR fixes it by introducing a `BackgroundActivityFactory`, which will create a `ZMBackgroundActivity` and giving it the `ZMSGroupQueue` it needs to switch to when ending the activity.

There are couple of API changes that are breaking:
- `ZMTransportSession` receive an additional parameter at initialization, which is the `ZMSGroupQueue` the background activity will switch to (has to be the main thread group queue)
- To create a `ZMBackgroundActivity`, one would need to use the `BackgroundActivityFactory` for that purpose.