### PR TITLE
Add transient argument to contructor

### DIFF
--- a/Source/Public/ZMUpdateEvent.h
+++ b/Source/Public/ZMUpdateEvent.h
@@ -113,7 +113,7 @@ typedef NS_ENUM(NSUInteger, ZMUpdateEventType) {
 + (nonnull instancetype)eventFromEventStreamPayload:(nonnull id<ZMTransportData>)payload uuid:(nullable NSUUID *)uuid;
 
 /// Creates an update event that was encrypted and it's now decrypted
-+ (nullable instancetype)decryptedUpdateEventFromEventStreamPayload:(nonnull id<ZMTransportData>)payload uuid:(nullable NSUUID *)uuid source:(ZMUpdateEventSource)source;
++ (nullable instancetype)decryptedUpdateEventFromEventStreamPayload:(nonnull id<ZMTransportData>)payload uuid:(nullable NSUUID *)uuid transient:(BOOL)transient source:(ZMUpdateEventSource)source;
 
 + (ZMUpdateEventType)updateEventTypeForEventTypeString:(nonnull NSString *)string;
 + (nullable NSString *)eventTypeStringForUpdateEventType:(ZMUpdateEventType)type;

--- a/Source/TransportEncoding/ZMUpdateEvent.m
+++ b/Source/TransportEncoding/ZMUpdateEvent.m
@@ -125,9 +125,9 @@
     return [[self alloc] initWithUUID:uuid payload:[payload asDictionary] transient:NO decrypted:NO source:ZMUpdateEventSourceDownload];
 }
 
-+ (nullable instancetype)decryptedUpdateEventFromEventStreamPayload:(nonnull id<ZMTransportData>)payload uuid:(nullable NSUUID *)uuid source:(ZMUpdateEventSource)source
++ (nullable instancetype)decryptedUpdateEventFromEventStreamPayload:(nonnull id<ZMTransportData>)payload uuid:(nullable NSUUID *)uuid transient:(BOOL)transient source:(ZMUpdateEventSource)source
 {
-    return [[self alloc] initWithUUID:uuid payload:[payload asDictionary] transient:NO decrypted:YES source:source];
+    return [[self alloc] initWithUUID:uuid payload:[payload asDictionary] transient:transient decrypted:YES source:source];
 }
 
 - (void)appendDebugInformation:(nonnull NSString *)debugInformation;

--- a/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
+++ b/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
@@ -440,7 +440,7 @@
 {
     [self performWithAllSourceTypes:^(ZMUpdateEventSource source) {
         NSUUID *identifier = NSUUID.createUUID;
-        ZMUpdateEvent *event = [ZMUpdateEvent decryptedUpdateEventFromEventStreamPayload:[self payloadFixtureWithID:identifier] uuid:identifier source:source];
+        ZMUpdateEvent *event = [ZMUpdateEvent decryptedUpdateEventFromEventStreamPayload:[self payloadFixtureWithID:identifier] uuid:identifier transient:NO source:source];
         XCTAssertEqual(event.source, source);
     }];
 }


### PR DESCRIPTION
## Why
This PR applies the hotfix made on the 9.0.1 release.

## What changed
`transient` argument added to the `ZMUpdateEvent` constructor.