### PR TITLE
Mark transportString on UUID as nonnull

### DIFF
--- a/Source/Public/NSObject+ZMTransportEncoding.h
+++ b/Source/Public/NSObject+ZMTransportEncoding.h
@@ -19,11 +19,10 @@
 
 #import <Foundation/Foundation.h>
 
-NS_ASSUME_NONNULL_BEGIN
 
 @protocol ZMTransportEncoding <NSObject>
 
-- (NSString *)transportString;
+- (nonnull NSString *)transportString;
 
 @end
 
@@ -31,17 +30,14 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSDate (ZMTransportEncoding) <ZMTransportEncoding>
 
-+ (nullable instancetype)dateWithTransportString:(NSString *)transportString;
++ (nullable instancetype)dateWithTransportString:(nonnull NSString *)transportString;
 
 @end
-
 
 
 
 @interface NSUUID (ZMTransportEncoding) <ZMTransportEncoding>
 
-+ (instancetype)uuidWithTransportString:(NSString *)transportString;
++ (nullable instancetype)uuidWithTransportString:(nonnull NSString *)transportString;
 
 @end
-
-NS_ASSUME_NONNULL_END

--- a/Source/Public/SwiftStructs+TransportEncoding.swift
+++ b/Source/Public/SwiftStructs+TransportEncoding.swift
@@ -19,10 +19,9 @@
 
 import Foundation
 
-
 public extension UUID {
 
-    func transportString() -> String? {
+    func transportString() -> String {
         return (self as NSUUID).transportString()
     }
 }

--- a/Source/Public/ZMPushChannelConnection.h
+++ b/Source/Public/ZMPushChannelConnection.h
@@ -33,8 +33,20 @@ NS_ASSUME_NONNULL_BEGIN
 /// a new instance needs to be created.
 @interface ZMPushChannelConnection : NSObject
 
-- (instancetype)initWithURL:(NSURL *)URL consumer:(id<ZMPushChannelConsumer>)consumer queue:(id<ZMSGroupQueue>)queue accessToken:(ZMAccessToken *)accessToken clientID:(NSString *)clientID userAgentString:(NSString *)userAgentString;
-- (instancetype)initWithURL:(NSURL *)URL consumer:(id<ZMPushChannelConsumer>)consumer queue:(id<ZMSGroupQueue>)queue webSocket:(nullable ZMWebSocket *)webSocket accessToken:(ZMAccessToken *)accessToken clientID:(nullable NSString *)clientID userAgentString:(NSString *)userAgentString NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithURL:(NSURL *)URL
+                            consumer:(id<ZMPushChannelConsumer>)consumer
+                               queue:(id<ZMSGroupQueue>)queue
+                         accessToken:(ZMAccessToken *)accessToken
+                            clientID:(NSString *)clientID
+                     userAgentString:(NSString *)userAgentString;
+
+- (instancetype)initWithURL:(NSURL *)URL
+                            consumer:(id<ZMPushChannelConsumer>)consumer
+                               queue:(id<ZMSGroupQueue>)queue
+                           webSocket:(nullable ZMWebSocket *)webSocket
+                         accessToken:(ZMAccessToken *)accessToken
+                            clientID:(nullable NSString *)clientID
+                     userAgentString:(NSString *)userAgentString NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, readonly, weak) id<ZMPushChannelConsumer> consumer;
 @property (nonatomic, readonly) BOOL isOpen;

--- a/Source/Public/ZMUpdateEvent.h
+++ b/Source/Public/ZMUpdateEvent.h
@@ -110,7 +110,7 @@ typedef NS_ENUM(NSUInteger, ZMUpdateEventType) {
 + (nullable NSArray<ZMUpdateEvent *> *)eventsArrayFromTransportData:(nonnull id<ZMTransportData>)transportData source:(ZMUpdateEventSource)source;
 
 /// Creates an update event
-+ (nonnull instancetype)eventFromEventStreamPayload:(nonnull id<ZMTransportData>)payload uuid:(nullable NSUUID *)uuid;
++ (nullable instancetype)eventFromEventStreamPayload:(nonnull id<ZMTransportData>)payload uuid:(nullable NSUUID *)uuid;
 
 /// Creates an update event that was encrypted and it's now decrypted
 + (nullable instancetype)decryptedUpdateEventFromEventStreamPayload:(nonnull id<ZMTransportData>)payload uuid:(nullable NSUUID *)uuid transient:(BOOL)transient source:(ZMUpdateEventSource)source;

--- a/Source/TransportEncoding/ZMUpdateEvent.m
+++ b/Source/TransportEncoding/ZMUpdateEvent.m
@@ -120,7 +120,7 @@
     return [self eventsArrayWithUUID:uuid payloadArray:payloadArray transient:transient source:source];
 }
 
-+ (instancetype)eventFromEventStreamPayload:(id<ZMTransportData>)payload uuid:(NSUUID *)uuid
++ (nullable instancetype)eventFromEventStreamPayload:(id<ZMTransportData>)payload uuid:(NSUUID *)uuid
 {
     return [[self alloc] initWithUUID:uuid payload:[payload asDictionary] transient:NO decrypted:NO source:ZMUpdateEventSourceDownload];
 }


### PR DESCRIPTION
# What's in this PR?

* Mark transportString on UUID as non null for better Swift integration