### PR TITLE
Create RequestLoopDetection to detect request loops

### DIFF
--- a/Source/URLSession/RequestLoopDetection.swift
+++ b/Source/URLSession/RequestLoopDetection.swift
@@ -1,9 +1,19 @@
 //
-//  RequestLoopDetection.swift
-//  ZMTransport
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
 //
-//  Created by Marco Conti on 17/10/16.
-//  Copyright © 2016 Wire. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation

--- a/Source/URLSession/RequestLoopDetection.swift
+++ b/Source/URLSession/RequestLoopDetection.swift
@@ -1,0 +1,116 @@
+//
+//  RequestLoopDetection.swift
+//  ZMTransport
+//
+//  Created by Marco Conti on 17/10/16.
+//  Copyright © 2016 Wire. All rights reserved.
+//
+
+import Foundation
+
+/// Records the URLs of REST requests sent over the network
+@objc protocol RequestRecorder : NSObjectProtocol {
+    
+    /// Records the URL of a REST request
+    func recordRequest(path: String, date: Date?)
+    
+}
+
+/// Monitors the REST requests that are sent over the network
+/// to detect suspicious request loops
+@objc public class RequestLoopDetection : NSObject {
+    
+    /// List of requests
+    fileprivate var recordedRequests : [DatePath] = []
+    
+    /// After this time, requests are purged from the list
+    static let decayTimer : TimeInterval = 60*5 // 10 minutes
+    
+    /// Repeatition warning trigger threshold
+    /// If a request is repeated more than this number of times,
+    /// it will trigger a warning
+    static let repetitionTriggerThreshold = 20
+    
+    /// Hard limit of URLs to keep in the history
+    static let historyLimit = 2000
+    
+    /// Trigger that will be invoked when a loop is detected
+    /// The URL passed is the URL that created the loop
+    fileprivate let triggerCallback : (String) -> (Void)
+    
+    public init(triggerCallback: @escaping (String)->(Void)) {
+        self.triggerCallback = triggerCallback
+    }
+}
+
+// MARK: - Loop detection
+extension RequestLoopDetection : RequestRecorder{
+    
+    /// Resets the detector, discarding all recorder requests
+    public func reset() {
+        self.recordedRequests = []
+    }
+    
+    public func recordRequest(path: String, date: Date?) {
+        purgeOldRequests()
+        if self.recordedRequests.count == type(of: self).historyLimit {
+            self.recordedRequests.remove(at: 0) // note, this would be more efficient with linked list
+        }
+        self.insertRequest(path: path, date: date ?? Date())
+        triggerIfTooMany(path: path)
+    }
+    
+    /// Removes requests that are too old from the recorded requests
+    private func purgeOldRequests() {
+        let purgeDate = Date(timeIntervalSinceNow: -type(of: self).decayTimer)
+        if let firstNonTooOldIndex = self.recordedRequests.index(where: {
+            $0.date > purgeDate
+        }) {
+            self.recordedRequests.removeFirst(firstNonTooOldIndex) // note, this would be more efficient with linked list
+        } else {
+            // all requests are old, kill them
+            reset()
+        }
+    }
+    
+    /// Insert request in the right date order in the array.
+    /// - note: Complexity: O(n). Could be made O(log(n)) with
+    /// binary search
+    private func insertRequest(path: String, date: Date) {
+        if date.timeIntervalSinceNow < -type(of: self).decayTimer {
+            return // not even adding, this is too old
+        }
+        
+        let datePath = DatePath(path: path, date: date)
+        
+        // I assume most (if not all) request are inserted in ascending order, so I will
+        // search backwards
+        var insertionIndex = 0
+        for i in (0..<self.recordedRequests.count).lazy.reversed() {
+            if self.recordedRequests[i].date < date {
+                insertionIndex = i+1
+                break
+            }
+        }
+        self.recordedRequests.insert(datePath, at: insertionIndex)
+    }
+    
+    /// Check if there are too many occurrences of a given URL
+    private func triggerIfTooMany(path: String) {
+        if self.recordedRequests
+            .filter({ $0.path == path })
+            .count >= type(of: self).repetitionTriggerThreshold {
+            // this could be slightly faster as we don't need to count, just stop after we found N
+            // (maybe there are N+1000 entries and we don't need to go through the additional 1000)
+            self.triggerCallback(path)
+            self.recordedRequests = self.recordedRequests.filter { $0.path != path }
+        }
+    }
+}
+
+
+fileprivate struct DatePath {
+    let path : String
+    let date : Date
+}
+

--- a/Tests/Source/URLSession/RequestLoopDetectionTests.swift
+++ b/Tests/Source/URLSession/RequestLoopDetectionTests.swift
@@ -1,9 +1,19 @@
 //
-//  RequestLoopDetectionTests.swift
-//  ZMTransport
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
 //
-//  Created by Marco Conti on 17/10/16.
-//  Copyright © 2016 Wire. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
 //
 
 import Foundation

--- a/Tests/Source/URLSession/RequestLoopDetectionTests.swift
+++ b/Tests/Source/URLSession/RequestLoopDetectionTests.swift
@@ -1,0 +1,142 @@
+//
+//  RequestLoopDetectionTests.swift
+//  ZMTransport
+//
+//  Created by Marco Conti on 17/10/16.
+//  Copyright © 2016 Wire. All rights reserved.
+//
+
+import Foundation
+import XCTest
+@testable import ZMTransport
+
+class RequestLoopDetectionTests : XCTestCase {
+    
+    func testThatItDetectsALoopWithOneRepeatedRequest() {
+        
+        // given
+        var triggered = false
+        let path = "foo.com"
+        
+        let sut = RequestLoopDetection() {
+            XCTAssertEqual(path, $0)
+            triggered = true
+        }
+        
+        // when
+        (0..<RequestLoopDetection.repetitionTriggerThreshold).forEach { _ in
+            sut.recordRequest(path: path, date: nil)
+        }
+        
+        // then
+        XCTAssertTrue(triggered)
+    }
+    
+    func testThatItDoesNotDetectsALoopWithOneRepeatedRequestIfMoreThan5MinutesApart() {
+        
+        // given
+        let path = "foo.com"
+        var startDate = Date(timeIntervalSince1970: 100)
+        
+        let sut = RequestLoopDetection() { _ in
+            XCTFail()
+        }
+        
+        // when
+        (0..<RequestLoopDetection.repetitionTriggerThreshold).forEach { _ in
+            sut.recordRequest(path: path, date: startDate)
+            startDate.addTimeInterval(10*60)
+        }
+    }
+    
+    func testThatItDoesNotDetectsALoopWithOneRepeatedRequesInsertedAtWrongTime() {
+        
+        // given
+        let path = "foo.com"
+        var startDate = Date()
+        
+        let sut = RequestLoopDetection() { _ in
+            XCTFail()
+        }
+        
+        // when
+        (0..<RequestLoopDetection.repetitionTriggerThreshold).forEach { _ in
+            sut.recordRequest(path: path, date: startDate)
+            startDate.addTimeInterval(-4*60)
+        }
+    }
+    
+    func testThatItDoesNotDetectsALoopWithManyDifferentRequest() {
+        
+        // given
+        let sut = RequestLoopDetection() { _ in
+            XCTFail()
+        }
+        
+        // when
+        (0..<RequestLoopDetection.repetitionTriggerThreshold).forEach {
+            sut.recordRequest(path: "foo.com/\($0)", date: nil)
+        }
+    }
+    
+    func testThatItDetectsALoopWithOneRepeatedRequestOnlyOnceEveryThreshold() {
+        
+        // given
+        let path = "foo.com"
+        var triggerCount = 0
+        
+        let sut = RequestLoopDetection() {
+            triggerCount += 1
+            XCTAssertEqual(path, $0)
+        }
+        
+        // when
+        (0..<RequestLoopDetection.repetitionTriggerThreshold*3).forEach { _ in
+            sut.recordRequest(path: path, date: nil)
+        }
+        
+        // then
+        XCTAssertEqual(triggerCount, 3)
+    }
+    
+    func testThatItDetectsMultipleLoopsFromDifferentURLs() {
+        
+        // given
+        var paths = ["foo.com", "bar.de", "baz.org"]
+        var triggeredURLs : [String] = []
+        
+        let sut = RequestLoopDetection() {
+            triggeredURLs.append($0)
+        }
+        
+        // when
+        (0..<RequestLoopDetection.repetitionTriggerThreshold*4).forEach {
+            let path = paths[$0 % paths.count] // this will insert them in interleaved order
+            sut.recordRequest(path: path, date: nil)
+         }
+        
+        // then
+        XCTAssertEqual(triggeredURLs, paths)
+    }
+    
+    func testThatItDoesNotStoreMoreThan2000URLs() {
+        
+        // given
+        let path = "MyURL.com"
+        var triggered = false
+        
+        let sut = RequestLoopDetection() { _ in
+            triggered = true
+        }
+        
+        // when
+        sut.recordRequest(path: path, date: nil)
+        (0..<2500).forEach {
+            sut.recordRequest(path: "url\($0).com", date: nil)
+        }
+        sut.recordRequest(path: path, date: nil)
+        
+        // then
+        XCTAssertFalse(triggered)
+    }
+}

--- a/ZMTransport.xcodeproj/project.pbxproj
+++ b/ZMTransport.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		09F028C61B7252FC00BADDB6 /* Lorem Ipsum.txt in Resources */ = {isa = PBXBuildFile; fileRef = 09F028C51B7252FC00BADDB6 /* Lorem Ipsum.txt */; };
 		3E88BCB31B1F35DF00232589 /* ZMTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BCA71B1F35DF00232589 /* ZMTransport.framework */; };
 		542434AC1BEA5C2500D33ACB /* Hack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 542434AB1BEA5C2500D33ACB /* Hack.swift */; };
+		5431ABFF1DB4C35B0040343C /* RequestLoopDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5431ABFE1DB4C35B0040343C /* RequestLoopDetection.swift */; };
+		5431AC011DB4C8330040343C /* RequestLoopDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5431AC001DB4C8330040343C /* RequestLoopDetectionTests.swift */; };
 		5451EF9E1B7A1359002F503B /* Collections+ZMTSafeTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5451EF9D1B7A1359002F503B /* Collections+ZMTSafeTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5451EFA01B7A138B002F503B /* Collections+ZMTSafeTypes.m in Sources */ = {isa = PBXBuildFile; fileRef = 5451EF9F1B7A138B002F503B /* Collections+ZMTSafeTypes.m */; };
 		5451EFA31B7A1458002F503B /* Collections+ZMTSafeTypesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5451EFA21B7A1458002F503B /* Collections+ZMTSafeTypesTests.m */; };
@@ -248,6 +250,8 @@
 		3E88BD221B1F383000232589 /* ZMTransport-Test-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ZMTransport-Test-Info.plist"; sourceTree = "<group>"; };
 		542434AA1BEA5C2400D33ACB /* ZMTransport-ios-tests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ZMTransport-ios-tests-Bridging-Header.h"; sourceTree = "<group>"; };
 		542434AB1BEA5C2500D33ACB /* Hack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Hack.swift; sourceTree = "<group>"; };
+		5431ABFE1DB4C35B0040343C /* RequestLoopDetection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestLoopDetection.swift; sourceTree = "<group>"; };
+		5431AC001DB4C8330040343C /* RequestLoopDetectionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestLoopDetectionTests.swift; sourceTree = "<group>"; };
 		544600D51BA9B7E000FAE908 /* ZMBackendEnvironment+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ZMBackendEnvironment+Testing.h"; sourceTree = "<group>"; };
 		5451EF9D1B7A1359002F503B /* Collections+ZMTSafeTypes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "Collections+ZMTSafeTypes.h"; sourceTree = "<group>"; };
 		5451EF9F1B7A138B002F503B /* Collections+ZMTSafeTypes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "Collections+ZMTSafeTypes.m"; sourceTree = "<group>"; };
@@ -646,6 +650,7 @@
 				546E89DB1B33015000DD1042 /* ZMURLSessionSwitchTests.m */,
 				546E89DC1B33015000DD1042 /* ZMURLSessionTests.m */,
 				BFEC39661CC6423700591F36 /* ZMTaskIdentifierTests.m */,
+				5431AC001DB4C8330040343C /* RequestLoopDetectionTests.swift */,
 			);
 			path = URLSession;
 			sourceTree = "<group>";
@@ -842,6 +847,7 @@
 				54CA154C1B32F2C1008D3787 /* ZMURLSessionSwitch.m */,
 				BF453F1B1CC63C4800403E1C /* ZMTaskIdentifier.h */,
 				BF453F1C1CC63C4800403E1C /* ZMTaskIdentifier.m */,
+				5431ABFE1DB4C35B0040343C /* RequestLoopDetection.swift */,
 			);
 			path = URLSession;
 			sourceTree = "<group>";
@@ -1113,6 +1119,7 @@
 				54CA15591B32F2C1008D3787 /* ZMSessionCancelTimer.m in Sources */,
 				BF3A7A641D8AD5430034FF40 /* SwiftStructs+TransportEncoding.swift in Sources */,
 				BF453F1E1CC63C4800403E1C /* ZMTaskIdentifier.m in Sources */,
+				5431ABFF1DB4C35B0040343C /* RequestLoopDetection.swift in Sources */,
 				5499FFC41B31C66D00835C8B /* ZMNetworkSocket.m in Sources */,
 				5499FFDE1B31C66D00835C8B /* ZMWebSocketHandshake.m in Sources */,
 				54CA15DC1B32F54B008D3787 /* TransportTracingProbes.d in Sources */,
@@ -1149,6 +1156,7 @@
 				546E89EB1B33015000DD1042 /* ZMNetworkSocketTest.m in Sources */,
 				546E89E91B33015000DD1042 /* ZMLiveWebSocketTests.m in Sources */,
 				546E89EF1B33015000DD1042 /* ZMTransportPushChannelTests.m in Sources */,
+				5431AC011DB4C8330040343C /* RequestLoopDetectionTests.swift in Sources */,
 				546E89F91B33015000DD1042 /* ZMTransportRequestTests.m in Sources */,
 				5451EFA31B7A1458002F503B /* Collections+ZMTSafeTypesTests.m in Sources */,
 				546E89E71B33015000DD1042 /* ZMDataBufferTests.m in Sources */,


### PR DESCRIPTION
# Reason for this pull request
We want to detect network requests loops that might cause the client to slow down and use too much network. This PR introduce the "RequestLoopDetection" class that keeps track of how often a path (from a URL) is being requested.

# Changes
Also removed tracing, which we don't support anymore

# Known issues
This is an incomplete implementation, another PR will hook up the request loop detection with the transport session