### PR TITLE
Add loop detection callback on transport session

### DIFF
--- a/Source/Public/ZMTransportRequest.h
+++ b/Source/Public/ZMTransportRequest.h
@@ -178,10 +178,12 @@ typedef NS_ENUM(int8_t, ZMTransportAccept) {
 @interface ZMTransportRequest (Debugging)
 
 @property (nonatomic, readonly, nullable) NSDate *startOfUploadTimestamp;
+@property (nonatomic, readonly) NSUInteger contentDebugInformationHash;
 
 - (void)setDebugInformationTranscoder:(NSObject *)transcoder;
 - (void)setDebugInformationState:(ZMSyncState *)state;
-- (void)appendDebugInformation:(NSString *)debugInformation;
+- (void)addContentDebugInformation:(NSString *)debugInformation;
+
 /// Marks the start of the upload time point
 - (void)markStartOfUploadTimestamp;
 

--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -69,8 +69,6 @@ extern NSString * const ZMTransportSessionShouldKeepWebsocketOpenKey;
 
 @end
 
-
-
 @interface ZMTransportSession : NSObject <ZMBackgroundable>
 
 @property (nonatomic, readonly, nullable) ZMAccessToken *accessToken;
@@ -79,8 +77,13 @@ extern NSString * const ZMTransportSessionShouldKeepWebsocketOpenKey;
 @property (nonatomic, assign) NSInteger maximumConcurrentRequests;
 @property (nonatomic, readonly) ZMPersistentCookieStorage *cookieStorage;
 @property (nonatomic) NSString *clientID;
+@property (nonatomic, copy) void (^requestLoopDetectionCallback)(NSString*);
 
-- (instancetype)initWithBaseURL:(NSURL *)baseURL websocketURL:(NSURL *)websocketURL keyValueStore:(id<ZMKeyValueStore>)keyValueStore mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue application:(UIApplication *)application;
+- (instancetype)initWithBaseURL:(NSURL *)baseURL
+                   websocketURL:(NSURL *)websocketURL
+                  keyValueStore:(id<ZMKeyValueStore>)keyValueStore
+                 mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
+                    application:(UIApplication *)application;
 
 - (void)tearDown;
 

--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -145,6 +145,8 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 @property (nonatomic) ZMTransportAccept acceptedResponseMediaTypes; ///< C.f. RFC 7231 section 5.3.2 <http://tools.ietf.org/html/rfc7231#section-5.3.2>
 @property (nonatomic) NSDate *timeoutDate;
 @property (nonatomic) NSMutableArray<NSString *>* debugInformation;
+/// Hash of the content debug information. This is used to identify the content of the request (e.g. detect repeated requests with the same content)
+@property (nonatomic) NSUInteger contentDebugInformationHash;
 @property (nonatomic) BOOL shouldCompress;
 @property (nonatomic) NSURL *fileUploadURL;
 @property (nonatomic) NSDate *startOfUploadTimestamp;
@@ -181,6 +183,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
         self.acceptedResponseMediaTypes = ZMTransportAcceptTransportData;
         self.shouldCompress = shouldCompress;
         self.debugInformation = [NSMutableArray array];
+        self.contentDebugInformationHash = 0;
     }
     return self;
 }
@@ -827,9 +830,10 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     [self.debugInformation addObject:[NSString stringWithFormat:@"Sync state: <%@> %p", NSStringFromClass(state.class), state]];
 }
 
-- (void)appendDebugInformation:(NSString *)debugInformation
+- (void)addContentDebugInformation:(NSString *)debugInformation
 {
     [self.debugInformation addObject:debugInformation];
+    self.contentDebugInformationHash ^= debugInformation.hash;
 }
 
 - (void)markStartOfUploadTimestamp {

--- a/Source/URLSession/RequestLoopDetection.swift
+++ b/Source/URLSession/RequestLoopDetection.swift
@@ -22,7 +22,7 @@ import Foundation
 @objc protocol RequestRecorder : NSObjectProtocol {
     
     /// Records a REST request
-    func recordRequest(path: String, contentHash: Int, date: Date?)
+    func recordRequest(path: String, contentHash: UInt, date: Date?)
     
 }
 
@@ -61,7 +61,7 @@ extension RequestLoopDetection : RequestRecorder{
         self.recordedRequests = []
     }
     
-    public func recordRequest(path: String, contentHash: Int, date: Date?) {
+    public func recordRequest(path: String, contentHash: UInt, date: Date?) {
         purgeOldRequests()
         if self.recordedRequests.count == type(of: self).historyLimit {
             self.recordedRequests.remove(at: 0) // note, this would be more efficient with linked list
@@ -123,7 +123,7 @@ fileprivate struct IdentifierDate {
     let date : Date
     let path : String
     
-    init(path: String, contentHash: Int, date: Date) {
+    init(path: String, contentHash: UInt, date: Date) {
         self.identifier = "\(path)[\(contentHash)]"
         self.date = date
         self.path = path

--- a/Tests/Source/Requests/ZMTransportRequestTests.m
+++ b/Tests/Source/Requests/ZMTransportRequestTests.m
@@ -972,8 +972,8 @@
     ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil];
     
     // when
-    [request appendDebugInformation:info1];
-    [request appendDebugInformation:info2];
+    [request addContentDebugInformation:info1];
+    [request addContentDebugInformation:info2];
     
     // then
     NSString *description = request.description;

--- a/Tests/Source/URLSession/RequestLoopDetectionTests.swift
+++ b/Tests/Source/URLSession/RequestLoopDetectionTests.swift
@@ -27,7 +27,7 @@ class RequestLoopDetectionTests : XCTestCase {
         // given
         var triggered = false
         let path = "foo.com"
-        let hash = 13
+        let hash : UInt = 13
         
         let sut = RequestLoopDetection() {
             XCTAssertEqual(path, $0)
@@ -47,7 +47,7 @@ class RequestLoopDetectionTests : XCTestCase {
         
         // given
         let path = "foo.com"
-        let hash = 13
+        let hash : UInt = 13
         var startDate = Date(timeIntervalSince1970: 100)
         
         let sut = RequestLoopDetection() { _ in
@@ -65,7 +65,7 @@ class RequestLoopDetectionTests : XCTestCase {
         
         // given
         let path = "foo.com"
-        let hash = 12
+        let hash : UInt = 12
         var startDate = Date()
         
         let sut = RequestLoopDetection() { _ in
@@ -82,7 +82,7 @@ class RequestLoopDetectionTests : XCTestCase {
     func testThatItDoesNotDetectsALoopIfPathIsNotSame() {
         
         // given
-        let hash = 14
+        let hash : UInt = 14
         let sut = RequestLoopDetection() { _ in
             XCTFail()
         }
@@ -102,7 +102,7 @@ class RequestLoopDetectionTests : XCTestCase {
         
         // when
         (0..<RequestLoopDetection.repetitionTriggerThreshold).forEach {
-            sut.recordRequest(path: "foo.com", contentHash: $0, date: nil)
+            sut.recordRequest(path: "foo.com", contentHash: UInt($0), date: nil)
         }
     }
     
@@ -111,7 +111,7 @@ class RequestLoopDetectionTests : XCTestCase {
         // given
         let path = "foo.com"
         var triggerCount = 0
-        let hash = 14
+        let hash : UInt = 14
         
         let sut = RequestLoopDetection() {
             triggerCount += 1
@@ -132,7 +132,7 @@ class RequestLoopDetectionTests : XCTestCase {
         // given
         var paths = ["foo.com", "bar.de", "baz.org"]
         var triggeredURLs : [String] = []
-        let hash = 14
+        let hash : UInt = 14
 
         
         let sut = RequestLoopDetection() {
@@ -163,7 +163,7 @@ class RequestLoopDetectionTests : XCTestCase {
         
         // when
         (0..<RequestLoopDetection.repetitionTriggerThreshold*4).forEach {
-            sut.recordRequest(path: path, contentHash: $0 % 3, date: nil)
+            sut.recordRequest(path: path, contentHash: UInt($0 % 3), date: nil)
         }
         
         // then
@@ -175,7 +175,7 @@ class RequestLoopDetectionTests : XCTestCase {
         // given
         let path = "MyURL.com"
         var triggered = false
-        let hash = 14
+        let hash : UInt = 14
 
         
         let sut = RequestLoopDetection() { _ in


### PR DESCRIPTION
# Reason for this pull request
We want to track if there is any request loop in the requests generated by the transport session. We use the content debug information, if present, to distinguish between requests to the same conversation that have different content. We can't use the actual payload of the request because any re-encrypted repeated message will have a different content, however the plain text content, which is attached to the request object for debug purposes, will be the same so we use its hash.
