### PR TITLE
Add optional pushStartingAt threshold parameter to update event array constructor

### DIFF
--- a/Source/Public/ZMUpdateEvent.h
+++ b/Source/Public/ZMUpdateEvent.h
@@ -107,6 +107,11 @@ typedef NS_ENUM(NSUInteger, ZMUpdateEventType) {
 @property (nonatomic, readonly, nullable) NSString *debugInformation;
 
 + (nullable NSArray<ZMUpdateEvent *> *)eventsArrayFromPushChannelData:(nonnull id<ZMTransportData>)transportData;
+
+/// Returns an array of @c ZMUpdateEvent from the given push channel data, the source will be set to @c
+/// ZMUpdateEventSourceWebSocket, if a non-nil @c NSUUID is given for the @c pushStartingAt parameter, all
+/// events earlier or equal to this uuid will have a source of @c ZMUpdateEventSourcePushNotification
++ (nullable NSArray *)eventsArrayFromPushChannelData:(nonnull id<ZMTransportData>)transportData pushStartingAt:(nullable NSUUID *)threshold;
 + (nullable NSArray<ZMUpdateEvent *> *)eventsArrayFromTransportData:(nonnull id<ZMTransportData>)transportData source:(ZMUpdateEventSource)source;
 
 /// Creates an update event

--- a/Source/TransportEncoding/ZMUpdateEvent.m
+++ b/Source/TransportEncoding/ZMUpdateEvent.m
@@ -91,7 +91,7 @@
     for(NSDictionary *payload in [payloadArray asDictionaries]) {
         ZMUpdateEventSource actualSource = source;
 
-        if (nil != sourceThreshold && [uuid compareWithType1UUID:sourceThreshold] != NSOrderedDescending) {
+        if (nil != sourceThreshold && [sourceThreshold compareWithType1UUID:uuid] != NSOrderedDescending) {
             actualSource = ZMUpdateEventSourcePushNotification;
         }
         ZMUpdateEvent *event = [[self alloc] initWithUUID:uuid payload:payload transient:transient decrypted:NO source:actualSource];

--- a/Source/TransportEncoding/ZMUpdateEvent.m
+++ b/Source/TransportEncoding/ZMUpdateEvent.m
@@ -23,6 +23,9 @@
 #import "NSString+UUID.h"
 #import <ZMTransport/ZMTransport-Swift.h>
 
+@import ZMUtilities;
+
+
 @interface NSDictionary (HashExtension)
 
 - (NSUInteger)zm_hash;
@@ -77,7 +80,7 @@
     return self;
 }
 
-+ (NSArray *)eventsArrayWithUUID:(NSUUID *)uuid payloadArray:(NSArray *)payloadArray transient:(BOOL)transient source:(ZMUpdateEventSource)source
++ (NSArray *)eventsArrayWithUUID:(NSUUID *)uuid payloadArray:(NSArray *)payloadArray transient:(BOOL)transient source:(ZMUpdateEventSource)source pushStartingAt:(NSUUID *)sourceThreshold
 {
     if (payloadArray == nil) {
         ZMLogError(@"Push event payload is invalid");
@@ -86,7 +89,12 @@
     
     NSMutableArray *events = [NSMutableArray array];
     for(NSDictionary *payload in [payloadArray asDictionaries]) {
-        ZMUpdateEvent *event = [[self alloc] initWithUUID:uuid payload:payload transient:transient decrypted:NO source:source];
+        ZMUpdateEventSource actualSource = source;
+
+        if (nil != sourceThreshold && [uuid compareWithType1UUID:sourceThreshold] != NSOrderedDescending) {
+            actualSource = ZMUpdateEventSourcePushNotification;
+        }
+        ZMUpdateEvent *event = [[self alloc] initWithUUID:uuid payload:payload transient:transient decrypted:NO source:actualSource];
         if (event != nil) {
             [events addObject:event];
         }
@@ -100,7 +108,17 @@
     return [self eventsArrayFromTransportData:transportData source:ZMUpdateEventSourceWebSocket];
 }
 
++ (NSArray *)eventsArrayFromPushChannelData:(id<ZMTransportData>)transportData pushStartingAt:(NSUUID *)threshold
+{
+    return [self eventsArrayFromTransportData:transportData source:ZMUpdateEventSourceWebSocket pushStartingAt:threshold];
+}
+
 + (NSArray *)eventsArrayFromTransportData:(id<ZMTransportData>)transportData source:(ZMUpdateEventSource)source
+{
+    return [self eventsArrayFromTransportData:transportData source:source pushStartingAt:nil];
+}
+
++ (NSArray *)eventsArrayFromTransportData:(id<ZMTransportData>)transportData source:(ZMUpdateEventSource)source pushStartingAt:(NSUUID *)threshold
 {
     NSDictionary *dictionary = [transportData asDictionary];
     
@@ -117,7 +135,7 @@
         return nil;
     }
     
-    return [self eventsArrayWithUUID:uuid payloadArray:payloadArray transient:transient source:source];
+    return [self eventsArrayWithUUID:uuid payloadArray:payloadArray transient:transient source:source pushStartingAt:threshold];
 }
 
 + (nullable instancetype)eventFromEventStreamPayload:(id<ZMTransportData>)payload uuid:(NSUUID *)uuid

--- a/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
+++ b/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
@@ -456,7 +456,12 @@
 
 - (void)testThatItDoesNotSetAnySourcesToPushWhenTheThresholdUUIDIsSetToNil
 {
-    NSArray <ZMUpdateEvent *> *events = [ZMUpdateEvent eventsArrayFromPushChannelData:self.payloadFixture pushStartingAt:nil];
+    // when
+    NSArray <ZMUpdateEvent *> *events = [ZMUpdateEvent eventsArrayFromPushChannelData:self.pushChannelDataFixture pushStartingAt:nil];
+
+    // then
+    XCTAssertEqual(events.count, 1lu);
+
     for (ZMUpdateEvent *event in events) {
         XCTAssertEqual(event.source, ZMUpdateEventSourceWebSocket);
     }

--- a/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
+++ b/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
@@ -465,27 +465,35 @@
 - (void)testThatItSetsTheSourceToPushForUUIDsEqualOrGreaterThanTheThresholdUUID
 {
     // Given
-    NSUUID *threshold = [NSUUID uuidWithTransportString:@"864fa306-99d1-11e6-bfff-22000a79a0f0"];
-    NSUUID *older = [NSUUID uuidWithTransportString:@"6f83dad4-99d1-11e6-bfff-22000a79a0f0"];
-    NSUUID *greater = [NSUUID uuidWithTransportString:@"937dc35a-99d1-11e6-bfff-22000a79a0f0"];
-    XCTAssertEqual([threshold compareWithType1UUID:older], NSOrderedDescending);
-    XCTAssertEqual([threshold compareWithType1UUID:greater], NSOrderedAscending);
+    NSUUID *threshold = [NSUUID uuidWithTransportString:@"864FA306-99D1-11E6-Bfff-22000A79A0F0"];
+    NSUUID *older = [NSUUID uuidWithTransportString:@"6f83DAd4-99D1-11E6-BFFF-22000A79A0f0"];
+    NSUUID *newer = [NSUUID uuidWithTransportString:@"937DC35A-99D1-11E6-BFFF-22000A79A0F0"];
 
-    NSArray <NSUUID *> *identifiers = @[older, threshold, greater];
+    XCTAssertEqual([threshold compareWithType1UUID:older], NSOrderedDescending);
+    XCTAssertEqual([threshold compareWithType1UUID:newer], NSOrderedAscending);
+
+    NSArray <NSUUID *> *identifiers = @[older, threshold, newer];
     for (NSUUID *identifier in identifiers) {
         XCTAssertTrue(identifier.isType1UUID);
     }
 
-    id <ZMTransportData> payload = [identifiers mapWithBlock:^id<ZMTransportData>(NSUUID *uuid){
-        return [self payloadFixtureWithID:uuid];
-    }];
-
     // When
-    NSArray <ZMUpdateEvent *> *events = [ZMUpdateEvent eventsArrayFromPushChannelData:payload pushStartingAt:threshold];
-    for (ZMUpdateEvent *event in events) {
-        // Then
-        XCTAssertEqual(event.source, [event.uuid isEqual:older] ? ZMUpdateEventSourceWebSocket : ZMUpdateEventSourcePushNotification);
-    }
+    NSArray <ZMUpdateEvent *> *oldestEvents = [ZMUpdateEvent eventsArrayFromPushChannelData:[self pushChannelDataFixtureWithId:older] pushStartingAt:threshold];
+    NSArray <ZMUpdateEvent *> *currentEvents = [ZMUpdateEvent eventsArrayFromPushChannelData:[self pushChannelDataFixtureWithId:threshold] pushStartingAt:threshold];
+    NSArray <ZMUpdateEvent *> *newerEvents = [ZMUpdateEvent eventsArrayFromPushChannelData:[self pushChannelDataFixtureWithId:newer] pushStartingAt:threshold];
+
+    // Then
+    XCTAssertNotNil(oldestEvents);
+    XCTAssertNotNil(currentEvents);
+    XCTAssertNotNil(newerEvents);
+
+    XCTAssertEqual(oldestEvents.count, 1lu);
+    XCTAssertEqual(currentEvents.count, 1lu);
+    XCTAssertEqual(newerEvents.count, 1lu);
+
+    XCTAssertEqual(oldestEvents.firstObject.source, ZMUpdateEventSourceWebSocket);
+    XCTAssertEqual(currentEvents.firstObject.source, ZMUpdateEventSourcePushNotification);
+    XCTAssertEqual(newerEvents.firstObject.source, ZMUpdateEventSourcePushNotification);
 }
 
 #pragma mark - Helper
@@ -518,7 +526,7 @@
 - (id <ZMTransportData>)pushChannelDataFixtureWithId:(NSUUID *)identifier
 {
     return @{
-             @"id" : identifier ?: @"0d30d26f-3b5e-4b7b-8f9a-efa2e5f9ca7a",
+             @"id" : identifier.transportString ?: @"0d30d26f-3b5e-4b7b-8f9a-efa2e5f9ca7a",
              @"payload" : @[
                      @{
                          @"type" : @"user.update",


### PR DESCRIPTION
# What's in this PR?

When parsing the notification stream in response to a push notification we want to mark all notifications that occurred after a given UUID (type 1) as push event source.
To achieve this the `ZMUpdateEvent` array factory method now has an optional `pushStartingAfter` parameter, if provided, all events greater than or equal to the given uuid will be marked as `ZMUpdateEventSourcePushNotification` while older ones will remain `ZMUpdateEventSourceWebSocket`. The reasoning behind this is that we want treat these update events as if they would have been received through a push notification in order to generate a local push.

With this we also have the option to pass in a computed UUID that is a couple of minutes in the past. That would allow missed notifications to be fully displayed, e.g. if the user was under bad network and received a fallback, he might receive another message 5 min afterwards when his network conditions recovered. If we pass in a uuid with a timestamp 10 min in the past we would display the full message text. The downside of this would of course be that the user would have one fallback and the full text notification for this message.