### PR TITLE
Cancel task immediately if it should not be restarted

### DIFF
--- a/Source/URLSession/ZMURLSession.m
+++ b/Source/URLSession/ZMURLSession.m
@@ -402,7 +402,11 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
     NOT_USED(session);
     NOT_USED(bytesSent);
-    
+
+    if (task.state == NSURLSessionTaskStateCanceling) {
+        return;
+    }
+
     ZMTransportRequest *request = [self requestForTask:task];
     float progress = 0;
     
@@ -415,6 +419,7 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
                                                            totalBytesExpected:totalBytesExpectedToSend];
         
         if (didFailRestartedRequest) {
+            [task cancel];
             return;
         }
     }


### PR DESCRIPTION
# What's in this PR?

* We check the progress of the file upload in `-[ZMURLSession(SessionDelegate) URLSession:task:didSendBodyData:totalBytesSent:totalBytesExpectedToSend:]` and fail it if the new progress is less than the new one, which indicates that the request has been restarted.
* If this happens we complete the request and the request strategy can cancel the task by calling back into the transport session. However I noticed that the transcoder got notified multiple times and found the issue in `[NSURLSession getTasksWithCompletionHandler:]` taking long until the completion handler gets called, in the meantime we continue uploading the file, receive the progress callback and inform the transcoder again. 
* To avoid this scenario we now immediately cancel the task in the transport session, this way the tasks state will be `NSURLSessionTaskStateCanceling ` and we avoid the roundtrip to the transcoder and back in order to cancel the task, as well as waiting for the completion handler to be called and ensure we only call the the transcoder once.
