### PR TITLE
Add NSNotFound check to multipart header parsing

### DIFF
--- a/Source/TransportEncoding/NSData+Multipart.m
+++ b/Source/TransportEncoding/NSData+Multipart.m
@@ -222,12 +222,14 @@ static NSString *const ContentLengthPrefix = @"Content-Length: ";
 {
     if (line != nil) {
         NSRange colonRange = [line rangeOfString:@": "];
-        NSString *key = [line substringToIndex:colonRange.location];
-        NSString *value = [line substringFromIndex:NSMaxRange(colonRange)];
-        if (key != nil && value != nil) {
-            [*headers setValue:value forKey:key];
+        if (colonRange.location != NSNotFound) {
+            NSString *key = [line substringToIndex:colonRange.location];
+            NSString *value = [line substringFromIndex:NSMaxRange(colonRange)];
+            if (key != nil && value != nil) {
+                [*headers setValue:value forKey:key];
+            }
+            return YES;
         }
-        return YES;
     }
     return NO;
 }

--- a/Tests/Source/TransportEncoding/NSData_MultipartTests.m
+++ b/Tests/Source/TransportEncoding/NSData_MultipartTests.m
@@ -185,4 +185,32 @@
     XCTAssertEqualObjects(createdItem, item);
 }
 
+- (void)testThatItIgnoresMalformattedHeaderValues
+{
+    // given
+    NSString *boundary = @"--boundary";
+    NSData *data = [@"1" dataUsingEncoding:NSUTF8StringEncoding];
+    
+    NSMutableData *malformedMultipartData = [NSMutableData data];
+    [malformedMultipartData appendData:[boundary dataUsingEncoding:NSUTF8StringEncoding]];
+    [malformedMultipartData appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+    [malformedMultipartData appendData:[@"Content-Length: 1" dataUsingEncoding:NSUTF8StringEncoding]];
+    [malformedMultipartData appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+    [malformedMultipartData appendData:[@"good: header" dataUsingEncoding:NSUTF8StringEncoding]];
+    [malformedMultipartData appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+    [malformedMultipartData appendData:[@"bad:header" dataUsingEncoding:NSUTF8StringEncoding]];
+    [malformedMultipartData appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+    [malformedMultipartData appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+    [malformedMultipartData appendData:data];
+    [malformedMultipartData appendData:[@"\r\n" dataUsingEncoding:NSUTF8StringEncoding]];
+    
+    // when
+    ZMMultipartBodyItem *createdItem = [[ZMMultipartBodyItem alloc] initWithMultipartData:malformedMultipartData];
+    
+    // then
+    XCTAssertEqual(createdItem.headers.count, 1u);
+    XCTAssertEqualObjects(createdItem.headers[@"good"], @"header");
+    XCTAssertEqualObjects(createdItem.data, data);
+}
+
 @end


### PR DESCRIPTION
We would crash on unexpected header lines which we can avoid by adding a `NSNotFound`check.

https://wearezeta.atlassian.net/browse/ZIOS-7679