### PR TITLE
Increase timeout for voip session

### DIFF
--- a/Source/Public/NSError+ZMTransportSession.h
+++ b/Source/Public/NSError+ZMTransportSession.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 + (NSError *)requestExpiredError;
 + (NSError *)tryAgainLaterError;
++ (NSError *)tryAgainLaterErrorWithUserInfo:(nullable NSDictionary *)userInfo;
 
 
 /// @c YES if the request what cancelled

--- a/Source/TransportSession/NSError+ZMTransportSession.m
+++ b/Source/TransportSession/NSError+ZMTransportSession.m
@@ -50,7 +50,12 @@ NSString * const ZMTransportSessionErrorDomain = @"ZMTransportSession";
 
 + (NSError *)tryAgainLaterError;
 {
-    return [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:nil];
+    return [self.class tryAgainLaterErrorWithUserInfo:nil];
+}
+
++ (NSError *)tryAgainLaterErrorWithUserInfo:(NSDictionary *)userInfo;
+{
+    return [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:userInfo];
 }
 
 
@@ -86,7 +91,8 @@ NSString * const ZMTransportSessionErrorDomain = @"ZMTransportSession";
     } else if (urlError.isCancelledURLTaskError && expired) {
         return [NSError requestExpiredError];
     }
-    return [NSError tryAgainLaterError];
+    NSDictionary *userInfo = @{NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Request finished with task error %@.", task.error.localizedDescription]};
+    return [NSError tryAgainLaterErrorWithUserInfo:userInfo];
 }
 
 @end

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -164,8 +164,8 @@ static NSInteger const DefaultMaximumRequests = 6;
 + (NSURLSessionConfiguration *)voipSessionConfiguration
 {
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration ephemeralSessionConfiguration];
-    configuration.timeoutIntervalForRequest = 15; // we need to make sure we are timing out before the time given to us ends
-    configuration.timeoutIntervalForResource = 20; // we need to make sure we are timing out before the time given to us ends
+    configuration.timeoutIntervalForRequest = 61; 
+    configuration.timeoutIntervalForResource = 12 * 60;
     configuration.networkServiceType = NSURLNetworkServiceTypeVoIP;
     [self setUpConfiguration:configuration];
     return configuration;
@@ -503,6 +503,9 @@ static NSInteger const DefaultMaximumRequests = 6;
     
     BOOL const expired = [self.expiredTasks containsObject:task];
     ZMLogDebug(@"Task %lu is %@", (unsigned long) task.taskIdentifier, expired ? @"expired" : @"NOT expired");
+    if (task.error != nil) {
+        ZMLogDebug(@"Task %lu finished with error: %@", (unsigned long) task.taskIdentifier, task.error.description);
+    }
     NSError *transportError = [NSError transportErrorFromURLTask:task expired:expired];
     ZMTransportResponse *response = [self transportResponseFromURLResponse:httpResponse data:data error:transportError];
     ZMLogInfo(@"<---- Response to %@ %@ (status %u): %@", [ZMTransportRequest stringForMethod:request.method], request.path, (unsigned) httpResponse.statusCode, response);
@@ -518,7 +521,8 @@ static NSInteger const DefaultMaximumRequests = 6;
     
     // If this requests needed authentication, but the access token wasn't valid, fail it:
     if (request.needsAuthentication && (httpResponse.statusCode == 401)) {
-        NSError *tryAgainError = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:nil];
+        NSDictionary *userInfo = @{@"NSLocalizedDescriptionKey": @"Request requiring authentication finished with 404 response. Make sure there is an access token."};
+        NSError *tryAgainError = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:userInfo];
         ZMTransportResponse *tryAgainResponse = [ZMTransportResponse responseWithTransportSessionError:tryAgainError];
         [request completeWithResponse:tryAgainResponse];
     } else {

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -521,7 +521,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     
     // If this requests needed authentication, but the access token wasn't valid, fail it:
     if (request.needsAuthentication && (httpResponse.statusCode == 401)) {
-        NSDictionary *userInfo = @{@"NSLocalizedDescriptionKey": @"Request requiring authentication finished with 404 response. Make sure there is an access token."};
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: @"Request requiring authentication finished with 404 response. Make sure there is an access token."};
         NSError *tryAgainError = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:userInfo];
         ZMTransportResponse *tryAgainResponse = [ZMTransportResponse responseWithTransportSessionError:tryAgainError];
         [request completeWithResponse:tryAgainResponse];

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -522,7 +522,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     // If this requests needed authentication, but the access token wasn't valid, fail it:
     if (request.needsAuthentication && (httpResponse.statusCode == 401)) {
         NSDictionary *userInfo = @{NSLocalizedDescriptionKey: @"Request requiring authentication finished with 404 response. Make sure there is an access token."};
-        NSError *tryAgainError = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:userInfo];
+        NSError *tryAgainError = [NSError tryAgainLaterErrorWithUserInfo:userInfo];
         ZMTransportResponse *tryAgainResponse = [ZMTransportResponse responseWithTransportSessionError:tryAgainError];
         [request completeWithResponse:tryAgainResponse];
     } else {
@@ -702,7 +702,8 @@ static NSInteger const DefaultMaximumRequests = 6;
 {
     ZMTransportRequest *request = item.transportRequest;
     if (request != nil) {
-        NSError *error = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:nil];
+        NSDictionary *userInfo = @{NSLocalizedDescriptionKey: @"Temporarily rejecting item to sync."};
+        NSError *error = [NSError tryAgainLaterErrorWithUserInfo:userInfo];
         ZMTransportResponse *tryAgainRespose = [ZMTransportResponse responseWithTransportSessionError:error];
         [request completeWithResponse:tryAgainRespose];
         [self decrementNumberOfRequestsInProgressAndNotifyOperationLoop:YES];


### PR DESCRIPTION
Requests to /notifications often fail after 15 sec due to a timeout on the NSURLSession. We increase the timeout. When creating the request, each request gets an expiration date which is decreased when the request is not a background URLSession request but performed while the app is in the background. 

Also added some extra logging for NSURLResponse errors.