### PR TITLE
Fix/remove key store for token

### DIFF
--- a/Source/Authentication/ZMAccessTokenHandler.h
+++ b/Source/Authentication/ZMAccessTokenHandler.h
@@ -31,13 +31,6 @@
 
 @end
 
-@protocol ZMKeyValueStore <NSObject>
-
-- (void)setValue:(id)value forKey:(NSString*)key;
-- (id)valueForKey:(NSString *)key;
-
-@end
-
 
 @class ZMSDispatchGroup;
 
@@ -49,8 +42,7 @@
                        delegate:(id<ZMAccessTokenHandlerDelegate>)delegate
                           queue:(NSOperationQueue *)queue
                           group:(ZMSDispatchGroup *)group
-                        backoff:(ZMExponentialBackoff *)backoff
-                  keyValueStore:(id<ZMKeyValueStore>)keyValueStore;
+                        backoff:(ZMExponentialBackoff *)backoff;
 
 - (void)setAccessTokenRenewalFailureHandler:(ZMCompletionHandlerBlock)handler;
 - (void)setAccessTokenRenewalSuccessHandler:(ZMAccessTokenHandlerBlock)handler;
@@ -79,9 +71,8 @@
 
 @interface ZMAccessTokenHandler (Testing)
 
-- (void)setAccessTokenForTesting:(ZMAccessToken *)accessToken;
+@property (nonatomic) ZMAccessToken* testing_accessToken;
 
 @property (nonatomic, readonly) NSURLSessionTask *currentAccessTokenTask;
-@property (nonatomic, readonly) NSString *lastKnownAccessTokenString;
 
 @end

--- a/Source/Authentication/ZMAccessTokenHandler.h
+++ b/Source/Authentication/ZMAccessTokenHandler.h
@@ -42,7 +42,8 @@
                        delegate:(id<ZMAccessTokenHandlerDelegate>)delegate
                           queue:(NSOperationQueue *)queue
                           group:(ZMSDispatchGroup *)group
-                        backoff:(ZMExponentialBackoff *)backoff;
+                        backoff:(ZMExponentialBackoff *)backoff
+             initialAccessToken:(ZMAccessToken *)initialAccessToken;
 
 - (void)setAccessTokenRenewalFailureHandler:(ZMCompletionHandlerBlock)handler;
 - (void)setAccessTokenRenewalSuccessHandler:(ZMAccessTokenHandlerBlock)handler;

--- a/Source/Authentication/ZMAccessTokenHandler.m
+++ b/Source/Authentication/ZMAccessTokenHandler.m
@@ -38,8 +38,6 @@
 
 
 static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
-static NSString * const ZMLastAccessTokenKey = @"ZMLastAccessToken";
-static NSString * const ZMLastAccessTokenTypeKey = @"ZMLastAccessTokenType";
 
 
 static NSTimeInterval const MininumSecondsAccessTokenNeedsToBeValid = 15;

--- a/Source/Authentication/ZMAccessTokenHandler.m
+++ b/Source/Authentication/ZMAccessTokenHandler.m
@@ -77,6 +77,7 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
                           queue:(NSOperationQueue *)queue
                           group:(ZMSDispatchGroup *)group
                         backoff:(ZMExponentialBackoff *)backoff
+             initialAccessToken:(ZMAccessToken *)initialAccessToken
 {
     self = [super init];
     if (self) {
@@ -86,6 +87,8 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
         self.group = group;
         self.workQueue = queue;
         self.backoff = backoff ?: [[ZMExponentialBackoff alloc] initWithGroup:self.group workQueue:self.workQueue];
+        self.accessToken = initialAccessToken;
+        self.lastKnownAccessToken = initialAccessToken;
     }
     return self;
 }

--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -81,7 +81,6 @@ extern NSString * const ZMTransportSessionShouldKeepWebsocketOpenKey;
 
 - (instancetype)initWithBaseURL:(NSURL *)baseURL
                    websocketURL:(NSURL *)websocketURL
-                  keyValueStore:(id<ZMKeyValueStore>)keyValueStore
                  mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
                     application:(nullable UIApplication *)application
       sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;

--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -82,6 +82,7 @@ extern NSString * const ZMTransportSessionShouldKeepWebsocketOpenKey;
 - (instancetype)initWithBaseURL:(NSURL *)baseURL
                    websocketURL:(NSURL *)websocketURL
                  mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
+             initialAccessToken:(ZMAccessToken *)initialAccessToken
                     application:(nullable UIApplication *)application
       sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;
 

--- a/Source/TransportSession/ZMTransportSession+internal.h
+++ b/Source/TransportSession/ZMTransportSession+internal.h
@@ -43,6 +43,7 @@
                             websocketURL:(NSURL *)websocketURL
                         pushChannelClass:(Class)pushChannelClass
                           mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
+                      initialAccessToken:(ZMAccessToken *)initialAccessToken
                              application:(UIApplication *)application NS_DESIGNATED_INITIALIZER;
 
 - (NSURLSessionTask *)suspendedTaskForRequest:(ZMTransportRequest *)request onSession:(ZMURLSession *)session;

--- a/Source/TransportSession/ZMTransportSession+internal.h
+++ b/Source/TransportSession/ZMTransportSession+internal.h
@@ -42,7 +42,6 @@
                                  baseURL:(NSURL *)baseURL
                             websocketURL:(NSURL *)websocketURL
                         pushChannelClass:(Class)pushChannelClass
-                           keyValueStore:(id<ZMKeyValueStore>)keyValueStore
                           mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
                              application:(UIApplication *)application NS_DESIGNATED_INITIALIZER;
 

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -118,7 +118,12 @@ static NSInteger const DefaultMaximumRequests = 6;
 - (instancetype)init
 {
     @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"You should not use -init" userInfo:nil];
-    return [self initWithBaseURL:nil websocketURL:nil mainGroupQueue:nil application:nil sharedContainerIdentifier:nil];
+    return [self initWithBaseURL:nil
+                    websocketURL:nil
+                  mainGroupQueue:nil
+              initialAccessToken:nil
+                     application:nil
+       sharedContainerIdentifier:nil];
 }
 
 + (void)setUpConfiguration:(NSURLSessionConfiguration *)configuration;
@@ -179,6 +184,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 - (instancetype)initWithBaseURL:(NSURL *)baseURL
                    websocketURL:(NSURL *)websocketURL
                  mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
+             initialAccessToken:(ZMAccessToken *)initialAccessToken
                     application:(UIApplication *)application
       sharedContainerIdentifier:(NSString *)sharedContainerIdentifier
 {
@@ -205,6 +211,7 @@ static NSInteger const DefaultMaximumRequests = 6;
                                   baseURL:baseURL
                              websocketURL:websocketURL
                            mainGroupQueue:mainGroupQueue
+                       initialAccessToken:initialAccessToken
                               application:application];
 }
 
@@ -216,6 +223,7 @@ static NSInteger const DefaultMaximumRequests = 6;
                                  baseURL:(NSURL *)baseURL
                             websocketURL:(NSURL *)websocketURL
                           mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
+                      initialAccessToken:(ZMAccessToken *)initialAccessToken
                              application:(UIApplication *)application
 {
     return [self initWithURLSessionSwitch:URLSessionSwitch
@@ -227,6 +235,7 @@ static NSInteger const DefaultMaximumRequests = 6;
                              websocketURL:websocketURL
                          pushChannelClass:nil
                            mainGroupQueue:mainGroupQueue
+                       initialAccessToken:initialAccessToken
                               application:application];
 }
 
@@ -240,6 +249,7 @@ static NSInteger const DefaultMaximumRequests = 6;
                             websocketURL:(NSURL *)websocketURL
                         pushChannelClass:(Class)pushChannelClass
                           mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
+                      initialAccessToken:(ZMAccessToken *)initialAccessToken
                              application:(UIApplication *)application
 {
     self = [super init];
@@ -273,7 +283,15 @@ static NSInteger const DefaultMaximumRequests = 6;
             pushChannelClass = ZMTransportPushChannel.class;
         }
         self.pushChannel = [[pushChannelClass alloc] initWithScheduler:self.requestScheduler userAgentString:[ZMUserAgent userAgentValue] URL:self.websocketURL];
-        self.accessTokenHandler = [[ZMAccessTokenHandler alloc] initWithBaseURL:baseURL cookieStorage:self.cookieStorage delegate:self queue:queue group:group backoff:nil];
+        self.accessTokenHandler = [[ZMAccessTokenHandler alloc] initWithBaseURL:baseURL
+                                                                  cookieStorage:self.cookieStorage
+                                                                       delegate:self
+                                                                          queue:queue
+                                                                          group:group
+                                                                        backoff:nil
+                                                             initialAccessToken:initialAccessToken
+
+                                   ];
         [self signUpForNotifications];
         ZM_WEAK(self);
         self.requestLoopDetection = [[RequestLoopDetection alloc] initWithTriggerCallback:^(NSString * _Nonnull path) {

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -118,7 +118,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 - (instancetype)init
 {
     @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"You should not use -init" userInfo:nil];
-    return [self initWithBaseURL:nil websocketURL:nil keyValueStore:nil mainGroupQueue:nil application:nil sharedContainerIdentifier:nil];
+    return [self initWithBaseURL:nil websocketURL:nil mainGroupQueue:nil application:nil sharedContainerIdentifier:nil];
 }
 
 + (void)setUpConfiguration:(NSURLSessionConfiguration *)configuration;
@@ -176,7 +176,11 @@ static NSInteger const DefaultMaximumRequests = 6;
     return configuration;
 }
 
-- (instancetype)initWithBaseURL:(NSURL *)baseURL websocketURL:(NSURL *)websocketURL keyValueStore:(id<ZMKeyValueStore>)keyValueStore mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue application:(UIApplication *)application sharedContainerIdentifier:(NSString *)sharedContainerIdentifier
+- (instancetype)initWithBaseURL:(NSURL *)baseURL
+                   websocketURL:(NSURL *)websocketURL
+                 mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
+                    application:(UIApplication *)application
+      sharedContainerIdentifier:(NSString *)sharedContainerIdentifier
 {
     NSOperationQueue *queue = [NSOperationQueue zm_serialQueueWithName:@"ZMTransportSession"];
     ZMSDispatchGroup *group = [ZMSDispatchGroup groupWithLabel:@"ZMTransportSession init"];
@@ -200,7 +204,6 @@ static NSInteger const DefaultMaximumRequests = 6;
                                     group:group
                                   baseURL:baseURL
                              websocketURL:websocketURL
-                            keyValueStore:keyValueStore
                            mainGroupQueue:mainGroupQueue
                               application:application];
 }
@@ -212,7 +215,6 @@ static NSInteger const DefaultMaximumRequests = 6;
                                    group:(ZMSDispatchGroup *)group
                                  baseURL:(NSURL *)baseURL
                             websocketURL:(NSURL *)websocketURL
-                           keyValueStore:(id<ZMKeyValueStore>)keyValueStore
                           mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
                              application:(UIApplication *)application
 {
@@ -224,7 +226,6 @@ static NSInteger const DefaultMaximumRequests = 6;
                                   baseURL:baseURL
                              websocketURL:websocketURL
                          pushChannelClass:nil
-                            keyValueStore:keyValueStore
                            mainGroupQueue:mainGroupQueue
                               application:application];
 }
@@ -238,7 +239,6 @@ static NSInteger const DefaultMaximumRequests = 6;
                                  baseURL:(NSURL *)baseURL
                             websocketURL:(NSURL *)websocketURL
                         pushChannelClass:(Class)pushChannelClass
-                           keyValueStore:(id<ZMKeyValueStore>)keyValueStore
                           mainGroupQueue:(id<ZMSGroupQueue>)mainGroupQueue
                              application:(UIApplication *)application
 {
@@ -273,7 +273,7 @@ static NSInteger const DefaultMaximumRequests = 6;
             pushChannelClass = ZMTransportPushChannel.class;
         }
         self.pushChannel = [[pushChannelClass alloc] initWithScheduler:self.requestScheduler userAgentString:[ZMUserAgent userAgentValue] URL:self.websocketURL];
-        self.accessTokenHandler = [[ZMAccessTokenHandler alloc] initWithBaseURL:baseURL cookieStorage:self.cookieStorage delegate:self queue:queue group:group backoff:nil keyValueStore:keyValueStore];
+        self.accessTokenHandler = [[ZMAccessTokenHandler alloc] initWithBaseURL:baseURL cookieStorage:self.cookieStorage delegate:self queue:queue group:group backoff:nil];
         [self signUpForNotifications];
         ZM_WEAK(self);
         self.requestLoopDetection = [[RequestLoopDetection alloc] initWithTriggerCallback:^(NSString * _Nonnull path) {
@@ -858,7 +858,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 - (void)setAccessToken:(ZMAccessToken *)accessToken;
 {
-    [self.accessTokenHandler setAccessTokenForTesting:accessToken];
+    self.accessTokenHandler.testing_accessToken = accessToken;
 }
 
 @end

--- a/Tests/Source/Authentication/ZMAccessTokenHandlerTests.m
+++ b/Tests/Source/Authentication/ZMAccessTokenHandlerTests.m
@@ -75,7 +75,12 @@
     self.backoff = [[FakeExponentialBackoff alloc] init];
     self.delegate = [[FakeDelegate alloc] init];
     
-    self.sut = [[ZMAccessTokenHandler alloc] initWithBaseURL:baseURL cookieStorage:self.cookieStorage delegate:self.delegate queue:self.queue group:self.dispatchGroup backoff:(id)self.backoff keyValueStore:[[FakeKeyValueStore alloc] init]];
+    self.sut = [[ZMAccessTokenHandler alloc] initWithBaseURL:baseURL
+                                               cookieStorage:self.cookieStorage
+                                                    delegate:self.delegate
+                                                       queue:self.queue
+                                                       group:self.dispatchGroup
+                                                     backoff:(id)self.backoff];
     
 }
 
@@ -162,7 +167,7 @@
     XCTAssertEqual(self.delegate.delegateCallCount, 0u);
 
     // when
-    [self.sut setAccessTokenForTesting:self.validAccessToken];
+    self.sut.testing_accessToken = self.validAccessToken;
     
     // then
     XCTAssertEqual(self.delegate.delegateCallCount, 1u);
@@ -202,7 +207,7 @@
 - (void)testThatItReturns_YES_ForCanStartRequestAccessToken_IfAccesToken_IsSet_And_NotAboutToExpire
 {
     // given
-    [self.sut setAccessTokenForTesting:self.validAccessToken];
+    self.sut.testing_accessToken = self.validAccessToken;
     XCTAssertNotNil(self.sut.accessToken);
     
     // when
@@ -215,7 +220,7 @@
 - (void)testThatItReturns_NO_ForCanStartRequestAccessToken_IfAccesToken_IsSet_And_Expired
 {
     // given
-    [self.sut setAccessTokenForTesting:self.expiredAccessToken];
+    self.sut.testing_accessToken = self.expiredAccessToken;
     XCTAssertNotNil(self.sut.accessToken);
     
     // when
@@ -231,7 +236,7 @@
     id transportRequest = [OCMockObject niceMockForClass:[ZMTransportRequest class]];
     [[[transportRequest expect] andReturnValue:OCMOCK_VALUE(YES)] needsAuthentication];
     
-    [self.sut setAccessTokenForTesting:self.validAccessToken];
+    self.sut.testing_accessToken = self.validAccessToken;
     
     NSMutableURLRequest *urlRequest = [NSMutableURLRequest requestWithURL:[NSURL new]];
     
@@ -460,7 +465,7 @@
 - (void)testThatItClearsAccessToken
 {
     // given
-    [self.sut setAccessTokenForTesting:self.validAccessToken];
+    self.sut.testing_accessToken = self.validAccessToken;
     XCTAssertNotNil([self.sut valueForKey:@"accessToken"]);
 
     FakeTransportResponse *testResponse = [FakeTransportResponse testResponse];
@@ -757,7 +762,7 @@
 - (void)testThatTheAccessTokenHasBeenSetWhenTheDelegateIsNotified_HandlerDidRecieveAccessToken
 {
     // given
-    [self.sut setAccessTokenForTesting:self.expiredAccessToken];
+    self.sut.testing_accessToken = self.expiredAccessToken;
     XCTAssertNotNil(self.sut.accessToken);
     NSString *expectedTokenString = @"new valid token";
     ZMAccessToken *token = [[ZMAccessToken alloc] initWithToken:expectedTokenString type:@"BEARER" expiresInSeconds:3000];
@@ -767,12 +772,12 @@
     // expect
     __weak typeof (self.sut) weakSut = self.sut;
     self.delegate.didReceiveAccessTokenBlock = ^{
-        lastKnownTokenString = weakSut.lastKnownAccessTokenString;
+        lastKnownTokenString = weakSut.testing_accessToken.token;
     };
     
     // when
     self.delegate.delegateCallCount = 0;
-    [self.sut setAccessTokenForTesting:token];
+    self.sut.testing_accessToken = token;
     
     // then
     XCTAssertEqual(self.delegate.delegateCallCount, 1lu);
@@ -782,7 +787,7 @@
 - (void)testThatItSetsTheAutorizationHeaderWithTheLastKnownAccessToken
 {
     // given
-    [self.sut setAccessTokenForTesting:self.validAccessToken];
+    self.sut.testing_accessToken = self.validAccessToken;
     XCTAssertNotNil(self.sut.accessToken);
     
     // expect that if it as an access token, it sets the correct header

--- a/Tests/Source/Authentication/ZMAccessTokenHandlerTests.m
+++ b/Tests/Source/Authentication/ZMAccessTokenHandlerTests.m
@@ -80,7 +80,9 @@
                                                     delegate:self.delegate
                                                        queue:self.queue
                                                        group:self.dispatchGroup
-                                                     backoff:(id)self.backoff];
+                                                     backoff:(id)self.backoff
+                                          initialAccessToken:nil
+                ];
     
 }
 

--- a/Tests/Source/Authentication/ZMAccessTokenHandlerTests.m
+++ b/Tests/Source/Authentication/ZMAccessTokenHandlerTests.m
@@ -75,15 +75,20 @@
     self.backoff = [[FakeExponentialBackoff alloc] init];
     self.delegate = [[FakeDelegate alloc] init];
     
+    [self createSutWithAccessToken:nil];
+}
+
+- (void)createSutWithAccessToken:(ZMAccessToken *)accessToken {
+    NSURL *baseURL = [NSURL URLWithString:@"http://www.example.com"];
+
     self.sut = [[ZMAccessTokenHandler alloc] initWithBaseURL:baseURL
                                                cookieStorage:self.cookieStorage
                                                     delegate:self.delegate
                                                        queue:self.queue
                                                        group:self.dispatchGroup
                                                      backoff:(id)self.backoff
-                                          initialAccessToken:nil
+                                          initialAccessToken:accessToken
                 ];
-    
 }
 
 - (void)tearDown {
@@ -209,7 +214,7 @@
 - (void)testThatItReturns_YES_ForCanStartRequestAccessToken_IfAccesToken_IsSet_And_NotAboutToExpire
 {
     // given
-    self.sut.testing_accessToken = self.validAccessToken;
+    [self createSutWithAccessToken:self.validAccessToken];
     XCTAssertNotNil(self.sut.accessToken);
     
     // when
@@ -222,7 +227,7 @@
 - (void)testThatItReturns_NO_ForCanStartRequestAccessToken_IfAccesToken_IsSet_And_Expired
 {
     // given
-    self.sut.testing_accessToken = self.expiredAccessToken;
+    [self createSutWithAccessToken:self.expiredAccessToken];
     XCTAssertNotNil(self.sut.accessToken);
     
     // when

--- a/Tests/Source/Fakes.h
+++ b/Tests/Source/Fakes.h
@@ -106,15 +106,3 @@
 @end
 
 
-
-
-//////////////////////////////////////////////////
-//
-#pragma mark - FakeKeyValueStore
-//
-//////////////////////////////////////////////////
-
-
-@interface FakeKeyValueStore : NSObject <ZMKeyValueStore>
-@property (nonatomic) NSMutableDictionary *store;
-@end

--- a/Tests/Source/Fakes.m
+++ b/Tests/Source/Fakes.m
@@ -174,30 +174,3 @@
 
 @end
 
-
-
-
-@implementation FakeKeyValueStore
-
-- (instancetype)init
-{
-    self = [super init];
-    if (self) {
-        self.store = [NSMutableDictionary dictionary];
-    }
-    return self;
-}
-
-
-- (void)setValue:(id)value forKey:(NSString *)key
-{
-    self.store[key] = value;
-}
-
-- (id)valueForKey:(NSString *)key
-{
-    return self.store[key];
-}
-
-
-@end

--- a/Tests/Source/TransportSession/ZMTransportRequestSchedulerTests.m
+++ b/Tests/Source/TransportSession/ZMTransportRequestSchedulerTests.m
@@ -1042,25 +1042,23 @@
 - (void)testThatItSwitchesToRetryStateAfterWaitingInRateLimitState;
 {
     // We'll run this a few times, since the time interval is randomly shifted, and we want to try a few outcomes:
-    for (int i = 0; i < 7; ++i) {
+    for (int i = 0; i < 5; ++i) {
         // given
-        NSTimeInterval const interval = 0.05;
+        NSTimeInterval const interval = 0.1;
         self.sut.timeUntilRetryModeWhenRateLimited = interval;
         
         // when
         self.sut.schedulerState = ZMTransportRequestSchedulerStateRateLimitedHoldingOff;
         
-        double const upperRandomAdjustment = 2.0;   // this is the max of the range of possible value
-        double const upperBackoffAdjustment = 1.15; // this is set to a value above the possible range in the test case
-        
-        // we create a date that is above to the limit mode time to ensure it switches time
-        NSDate *high = [NSDate dateWithTimeIntervalSinceNow:upperBackoffAdjustment * upperRandomAdjustment * interval];
-        
         // then
         
         // backoffAdjustement * randrom adjustment * interval
-        [self spinMainQueueWithTimeout: 0.5 * 0.1 * interval];
+        [self spinMainQueueWithTimeout: 0.1 * interval];
         XCTAssertNotEqual(self.sut.schedulerState, ZMTransportRequestSchedulerStateRateLimitedRetrying, @"Iteration: %d", i);
+        
+        // we create a date that is above to the limit mode time to ensure it switches time
+        NSDate *high = [NSDate dateWithTimeIntervalSinceNow:interval * 2];
+        
         XCTAssertTrue([self waitUntilDate:high verificationBlock:^BOOL{
             return (self.sut.schedulerState == ZMTransportRequestSchedulerStateRateLimitedRetrying);
         }]);

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -452,7 +452,6 @@ static __weak FakeReachability *currentReachability;
                 baseURL:self.baseURL
                 websocketURL:self.webSocketURL
                 pushChannelClass:FakePushChannel.class
-                keyValueStore:[[FakeKeyValueStore alloc] init]
                 mainGroupQueue:[[FakeGroupQueue alloc] init]
                 application:[UIApplication sharedApplication]];
     __weak id weakSelf = self;
@@ -576,7 +575,6 @@ static __weak FakeReachability *currentReachability;
                 baseURL:url
                 websocketURL:url2
                 pushChannelClass:nil
-                keyValueStore:[[FakeKeyValueStore alloc] init]
                 mainGroupQueue:[[FakeGroupQueue alloc] init]
                 application:[UIApplication sharedApplication]];
     
@@ -794,7 +792,6 @@ static __weak FakeReachability *currentReachability;
                                baseURL:url
                                websocketURL:url
                                pushChannelClass:nil
-                               keyValueStore:[[FakeKeyValueStore alloc] init]
                                mainGroupQueue:[[FakeGroupQueue alloc] init]
                                application:[UIApplication sharedApplication]];
     
@@ -834,7 +831,6 @@ static __weak FakeReachability *currentReachability;
                                baseURL:url
                                websocketURL:url
                                pushChannelClass:nil
-                               keyValueStore:[[FakeKeyValueStore alloc] init]
                                mainGroupQueue:nil
                                application:[UIApplication sharedApplication]];
     

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -453,6 +453,7 @@ static __weak FakeReachability *currentReachability;
                 websocketURL:self.webSocketURL
                 pushChannelClass:FakePushChannel.class
                 mainGroupQueue:[[FakeGroupQueue alloc] init]
+                initialAccessToken:nil
                 application:[UIApplication sharedApplication]];
     __weak id weakSelf = self;
     [self.sut setAccessTokenRenewalFailureHandler:^(ZMTransportResponse *response) {
@@ -576,6 +577,7 @@ static __weak FakeReachability *currentReachability;
                 websocketURL:url2
                 pushChannelClass:nil
                 mainGroupQueue:[[FakeGroupQueue alloc] init]
+                initialAccessToken:nil
                 application:[UIApplication sharedApplication]];
     
     self.sut.accessToken = self.validAccessToken;
@@ -793,6 +795,7 @@ static __weak FakeReachability *currentReachability;
                                websocketURL:url
                                pushChannelClass:nil
                                mainGroupQueue:[[FakeGroupQueue alloc] init]
+                               initialAccessToken:nil
                                application:[UIApplication sharedApplication]];
     
     sut.accessToken = self.validAccessToken;
@@ -832,6 +835,7 @@ static __weak FakeReachability *currentReachability;
                                websocketURL:url
                                pushChannelClass:nil
                                mainGroupQueue:nil
+                               initialAccessToken:nil
                                application:[UIApplication sharedApplication]];
     
     sut.accessToken = self.validAccessToken;


### PR DESCRIPTION
# Reason for this pull request
Passing a managed object context as key store to be able to store the access token was unnecessarily complicated. We just need to pass an initial access token value.

The caller can then manage the persistence of the access token if needed. The caller will be notified if the access token changed with the already existing infrastructure.

This fixes a Core Data concurrency issue