### PR TITLE
Mark parameterless init of ZMBackendEnvironment as unavailable

### DIFF
--- a/Source/Public/ZMBackendEnvironment.h
+++ b/Source/Public/ZMBackendEnvironment.h
@@ -47,6 +47,8 @@ extern NSString * const ZMBackendEnvironmentTypeKey;
 /// Returns an environment of the given type
 + (instancetype)environmentWithType:(ZMBackendEnvironmentType)type;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /// Returns an environment of the type specified in the user defaults
 - (instancetype)initWithUserDefaults:(NSUserDefaults *)defaults;
 


### PR DESCRIPTION
# What's in this PR?

* This initializer should not be used and thus is now marked as `NS_UNAVAILABLE`. 