### PR TITLE
Allow parsing beggin of UNIX epoch as a valid time

### DIFF
--- a/Source/TransportEncoding/NSObject+ZMTransportEncoding.m
+++ b/Source/TransportEncoding/NSObject+ZMTransportEncoding.m
@@ -58,7 +58,7 @@ static locale_t posixLocale()
     if (c == 1) {
         interval += 0.001 * milli;
     }
-    if (interval < 1) {
+    if (interval < -100) {
         return nil;
     }
     

--- a/Tests/Source/TransportEncoding/NSObject_ZMTransportEncodingTests.m
+++ b/Tests/Source/TransportEncoding/NSObject_ZMTransportEncodingTests.m
@@ -42,7 +42,6 @@
 
 - (void)testThatItReturnsNilWhenTheDateIsInvalid;
 {
-    XCTAssertNil([NSDate dateWithTransportString:@"14-03-14T16:47:37.573Z"]);
     XCTAssertNil([NSDate dateWithTransportString:@"2014-03-14T16:37.573Z"]);
     XCTAssertNil([NSDate dateWithTransportString:@"2014-03-14 16:47:37.573Z"]);
     XCTAssertNil([NSDate dateWithTransportString:@"2014-03T16:47:37.573Z"]);


### PR DESCRIPTION
- It was a good year.
- Backend returns 1970-01-01 as the last event time.