### PR TITLE
Increase threshold to stop detecting self requests as a loop on sign in

### DIFF
--- a/Source/URLSession/RequestLoopDetection.swift
+++ b/Source/URLSession/RequestLoopDetection.swift
@@ -39,10 +39,10 @@ import Foundation
     /// Repeatition warning trigger threshold
     /// If a request is repeated more than this number of times,
     /// it will trigger a warning
-    static let repetitionTriggerThreshold = 10
+    static let repetitionTriggerThreshold = 20
     
     /// Hard limit of URLs to keep in the history
-    static let historyLimit = 60
+    static let historyLimit = 120
     
     /// Trigger that will be invoked when a loop is detected
     /// The URL passed is the URL that created the loop


### PR DESCRIPTION
# Issue

On the automation we see time to time that `/self` request is detected as a loop, but not always. After investigating this matter it looks like the self is requested several times, but those are valid requests (waiting for email confirmation for example). Not clear why the issue is showed up now.

# Preliminary solution

Increase the threshold should unblock the automation, if it does not happen then we would need to look for some other solution.