### PR TITLE
Dispose push channel threads on close

### DIFF
--- a/Source/PushChannel/ZMNetworkSocket.m
+++ b/Source/PushChannel/ZMNetworkSocket.m
@@ -87,7 +87,7 @@ NS_ENUM(int, Trace) {
     // The compare & swap ensure that the code only runs if the values of isClosed was 0 and sets it to 1.
     // The check for 0 and setting it to 1 happen as a single atomic operation.
     if (OSAtomicCompareAndSwap32Barrier(1, 0, &_isOpen)) {
-        self.streamPairThread.shouldKeepRunning = NO;
+        [self.streamPairThread cancel];
         self.inputStream.delegate = nil;
         self.outputStream.delegate = nil;
         [self.delegateGroup asyncOnQueue:self.dataBufferIsolation block:^{

--- a/Source/PushChannel/ZMStreamPairThread.h
+++ b/Source/PushChannel/ZMStreamPairThread.h
@@ -19,12 +19,8 @@
 
 #import <Foundation/Foundation.h>
 
-
-
 @interface ZMStreamPairThread : NSThread
 
 - (instancetype)initWithInputStream:(NSInputStream *)inputStream outputStream:(NSOutputStream *)outputStream;
-
-@property (nonatomic) BOOL shouldKeepRunning;
 
 @end

--- a/Source/PushChannel/ZMStreamPairThread.m
+++ b/Source/PushChannel/ZMStreamPairThread.m
@@ -20,28 +20,12 @@
 #import "ZMStreamPairThread.h"
 @import WireSystem;
 
-@import ObjectiveC;
-
-
-
 @interface ZMStreamPairThread ()
 
 @property (nonatomic) NSInputStream *inputStream;
 @property (nonatomic) NSOutputStream *outputStream;
 
 @end
-
-
-static BOOL canSetQualityOfService()
-{
-    static BOOL canSet;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        canSet = (NULL != class_getProperty([ZMStreamPairThread class], "numberOfValidItemsForDrop"));
-    });
-    return canSet;
-}
-
 
 @implementation ZMStreamPairThread
 
@@ -54,9 +38,6 @@ static BOOL canSetQualityOfService()
         self.inputStream = inputStream;
         self.outputStream = outputStream;
         self.name = @"ZMStreamPairThread";
-        if (canSetQualityOfService()) {
-            self.qualityOfService = NSQualityOfServiceUtility;
-        }
     }
     return self;
 }

--- a/Source/PushChannel/ZMStreamPairThread.m
+++ b/Source/PushChannel/ZMStreamPairThread.m
@@ -51,7 +51,6 @@ static BOOL canSetQualityOfService()
     VerifyReturnNil(outputStream != nil);
     self = [super init];
     if (self) {
-        self.shouldKeepRunning = YES;
         self.inputStream = inputStream;
         self.outputStream = outputStream;
         self.name = @"ZMStreamPairThread";
@@ -67,8 +66,10 @@ static BOOL canSetQualityOfService()
     NSRunLoop *loop = [NSRunLoop currentRunLoop];
     [self.inputStream scheduleInRunLoop:loop forMode:NSDefaultRunLoopMode];
     [self.outputStream scheduleInRunLoop:loop forMode:NSDefaultRunLoopMode];
-    while (self.shouldKeepRunning && [loop runMode:NSDefaultRunLoopMode beforeDate:[NSDate distantFuture]])
+    while (!self.isCancelled && [loop runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:1]])
     {}
+    [self.inputStream removeFromRunLoop:loop forMode:NSDefaultRunLoopMode];
+    [self.outputStream removeFromRunLoop:loop forMode:NSDefaultRunLoopMode];
 }
 
 @end


### PR DESCRIPTION
## The reason behind this PR

When investigating a crash we have been having for quite a while I notice that crash logs contain many threads - sometimes 50 or 60. We have a custom `NSThread` subclass that is used for push channel input/output and is recreated every time the app comes back from background. Unfortunately it was not disposed correctly and stayed in memory.

## How it was fixed

It was not being released because it was waiting for events in the runloop without timeout (with `beforeDate:[NSDate distantFuture]`). This prevented the cancellation flag to be re-evaluated and kept the thread waiting and never had a chance to de-allocate.

Also removed a code that was checking for a property to exist which was never there and always evaluating to false.