### PR TITLE
Removing stream from runloop seems to crash when offline

### DIFF
--- a/Source/PushChannel/ZMStreamPairThread.m
+++ b/Source/PushChannel/ZMStreamPairThread.m
@@ -49,8 +49,6 @@
     [self.outputStream scheduleInRunLoop:loop forMode:NSDefaultRunLoopMode];
     while (!self.isCancelled && [loop runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:1]])
     {}
-    [self.inputStream removeFromRunLoop:loop forMode:NSDefaultRunLoopMode];
-    [self.outputStream removeFromRunLoop:loop forMode:NSDefaultRunLoopMode];
 }
 
 @end


### PR DESCRIPTION
Not removing them from runloop doesn't seem to make a difference, the `ZMStreamPairThread` still gets deallocated as expected.