### PR TITLE
Indication of the errors that cannot be recovered by re-syncing

### DIFF
--- a/Source/Public/ZMTransportResponse.h
+++ b/Source/Public/ZMTransportResponse.h
@@ -71,6 +71,10 @@ typedef NS_ENUM(uint8_t, ZMTransportResponseStatus) {
 @end
 
 
+@interface ZMTransportResponse (PermanentlyUnavailable)
+- (BOOL)isPermanentylUnavailableError;
+@end
+
 
 @interface NSHTTPURLResponse (ZMTransportResponse)
 

--- a/Source/Requests/ZMTransportResponse.m
+++ b/Source/Requests/ZMTransportResponse.m
@@ -170,6 +170,29 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 @end
 
 
+@implementation ZMTransportResponse (PermanentlyUnavailable)
+
+- (BOOL)isPermanentylUnavailableError
+{
+    static uint16_t const permanentylUnavailableHTTPResponseCodes[] = {400, 403, 404, 405, 406, 410, 412, 451, 0};
+    // expected to be 0-terminated
+    
+    if (self.result != ZMTransportResponseStatusPermanentError) {
+        return NO;
+    }
+    
+    for (size_t index = 0; permanentylUnavailableHTTPResponseCodes[index] != 0; index++) {
+        if (permanentylUnavailableHTTPResponseCodes[index] == self.HTTPStatus) {
+            return YES;
+        }
+    }
+    
+    return NO;
+}
+
+@end
+
+
 
 @implementation NSHTTPURLResponse (ZMTransportResponse)
 

--- a/Source/Requests/ZMTransportResponse.m
+++ b/Source/Requests/ZMTransportResponse.m
@@ -174,14 +174,14 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 
 - (BOOL)isPermanentylUnavailableError
 {
-    static uint16_t const permanentylUnavailableHTTPResponseCodes[] = {400, 403, 404, 405, 406, 410, 412, 451, 0};
-    // expected to be 0-terminated
-    
+    static uint16_t const permanentylUnavailableHTTPResponseCodes[] = {400, 403, 404, 405, 406, 410, 412, 451};
+    static size_t const length = sizeof(permanentylUnavailableHTTPResponseCodes)/sizeof(permanentylUnavailableHTTPResponseCodes[0]);
+
     if (self.result != ZMTransportResponseStatusPermanentError) {
         return NO;
     }
     
-    for (size_t index = 0; permanentylUnavailableHTTPResponseCodes[index] != 0; index++) {
+    for (size_t index = 0; index < length; index++) {
         if (permanentylUnavailableHTTPResponseCodes[index] == self.HTTPStatus) {
             return YES;
         }

--- a/Tests/Source/Requests/ZMTransportResponseTests.m
+++ b/Tests/Source/Requests/ZMTransportResponseTests.m
@@ -53,6 +53,36 @@
     }];
 }
 
+- (void)testThatItReturnsPermanentErrorForCodes
+{
+    [self performIgnoringZMLogError:^{
+        NSArray<NSNumber *> * permanentErrors = @[@(400), @(403), @(404), @(405), @(406), @(410), @(412), @(451)];
+        for (NSNumber *code in permanentErrors) {
+            ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:code.integerValue transportSessionError:nil];
+            XCTAssertTrue(response.isPermanentylUnavailableError);
+        }
+    }];
+}
+
+- (void)testThatItReturnsNoPermanentErrorForCodes
+{
+    [self performIgnoringZMLogError:^{
+        NSArray<NSNumber *> * permanentErrors = @[@(401), @(500), @(201), @(302)];
+        for (NSNumber *code in permanentErrors) {
+            ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:code.integerValue transportSessionError:nil];
+            XCTAssertFalse(response.isPermanentylUnavailableError);
+        }
+    }];
+}
+
+- (void)testThatItReturnsNoPermanentErrorForSuccess
+{
+    for(int status = 200; status < 300; ++status) {
+        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:status transportSessionError:nil];
+        XCTAssertFalse(response.isPermanentylUnavailableError);
+    }
+}
+
 - (void)testThatItReturnSuccess
 {
     for(int status = 200; status < 300; ++status) {


### PR DESCRIPTION
# Issue

Needed to avoid looping over the endpoints where we would not ever get the access too, for example:

1. User leaves the conversation.
1. Conversation is marked for some reason as to be re-fetched from the backend.
1. Backend returns 404.
-> App goes into the loop. 

