### PR TITLE
Fix push channel issues

### DIFF
--- a/Source/Public/ZMPushChannelConnection.h
+++ b/Source/Public/ZMPushChannelConnection.h
@@ -50,6 +50,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, weak) id<ZMPushChannelConsumer> consumer;
 @property (nonatomic, readonly) BOOL isOpen;
+@property (nonatomic, readonly) BOOL didCompleteHandshake;
 
 - (void)checkConnection;
 

--- a/Source/Public/ZMReachability.h
+++ b/Source/Public/ZMReachability.h
@@ -37,6 +37,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// In reverse, this returns @c YES when there's a chance that we may be able to connect to at least one of the named servers.
 @property (atomic, readonly) BOOL mayBeReachable;
 @property (atomic, readonly) BOOL isMobileConnection;
+@property (atomic, readonly) BOOL oldMayBeReachable;
+@property (atomic, readonly) BOOL oldIsMobileConnection;
 
 @end
 

--- a/Source/PushChannel/ZMWebSocket.h
+++ b/Source/PushChannel/ZMWebSocket.h
@@ -38,6 +38,8 @@
 - (void)sendBinaryFrameWithData:(NSData *)data;
 - (void)sendPingFrame;
 
+@property (nonatomic, readonly) BOOL handshakeCompleted;
+
 @end
 
 

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -769,6 +769,11 @@ static NSInteger const DefaultMaximumRequests = 6;
     [self.requestScheduler reachabilityDidChange:reachability];
     [self.pushChannel reachabilityDidChange:reachability];
 
+    BOOL didGoOnline = reachability.mayBeReachable && !reachability.oldMayBeReachable;
+    if (didGoOnline && !self.accessTokenHandler.canStartRequestWithAccessToken) {
+        [self sendAccessTokenRequest];
+    }
+    
     id<ZMNetworkStateDelegate> networkStateDelegate = self.weakNetworkStateDelegate;
     if(self.reachability.mayBeReachable) {
         [networkStateDelegate didReceiveData];

--- a/Source/URLSession/ZMReachability.m
+++ b/Source/URLSession/ZMReachability.m
@@ -42,6 +42,8 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 @property (nonatomic) NSMapTable *referenceToName;
 @property (atomic) BOOL mayBeReachable;
 @property (atomic) BOOL isMobileConnection;
+@property (atomic) BOOL oldMayBeReachable;
+@property (atomic) BOOL oldIsMobileConnection;
 
 @end
 
@@ -181,6 +183,8 @@ static CFStringRef copyDescription(const void *info)
     
     [self.group enter];
     [self.observerQueue addOperationWithBlock:^{
+        self.oldMayBeReachable = self.mayBeReachable;
+        self.oldIsMobileConnection = self.isMobileConnection;
         self.mayBeReachable = globalReachable;
         self.isMobileConnection = isMobileConnection;
         [self.reachabilityObserver reachabilityDidChange:self];


### PR DESCRIPTION
Several issues were fixed
(1) When the app launches without connectivity and then gains internet connection, we failed to open the push channel due to a missing access token. The access token was only renewed once a request was sent (e.g. by avs polling for calls). 
Solution: When reachability changed to maybeReachable and the accessToken expired, we send an accessTokenRequest.

(2) When the app has no internet we optimistically constantly try to reestablish the websocket. There is a race condition where we send a handshake frame while the app is offline and then regain connectivity. In this case the handshake is not sent again and the websocket not properly setup. 
Solution: When we regain internet and have an open websocket, we close the old one and create a new one.

(3) There were rare crashes where we were trying to write into the output stream while it was already writing. This caused a crash. We now silently fail by skipping the write. Since we are only sending pings, this should be fine.

(4) Websockets / Networksockets were not properly released and kept trying to ping.