### PR TITLE
Codecov: fix coverage tracking

### DIFF
--- a/WireTransport.xcodeproj/xcshareddata/xcschemes/WireTransport.xcscheme
+++ b/WireTransport.xcodeproj/xcshareddata/xcschemes/WireTransport.xcscheme
@@ -20,27 +20,14 @@
                ReferencedContainer = "container:WireTransport.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "NO"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "3E88BCB11B1F35DF00232589"
-               BuildableName = "WireTransport-ios-tests.xctest"
-               BlueprintName = "WireTransport-ios-tests"
-               ReferencedContainer = "container:WireTransport.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Code coverage tracking didn't work with this framework. Our scheme was created before project rename and seems to be somewhat malformed - my suspicion is because scheme was named `WireTransport-ios`, but the product was `WireTransport`