### PR TITLE
Extra guard to check if dataBufferIsolation exist

### DIFF
--- a/Source/PushChannel/ZMNetworkSocket.m
+++ b/Source/PushChannel/ZMNetworkSocket.m
@@ -231,6 +231,12 @@ NS_ENUM(int, Trace) {
         return;
     }
     
+    // Socket is closed.
+    if (self.dataBufferIsolation == nil) {
+        ZMLogError(@"%@: dataBufferIsolation is nil", self);
+        return;
+    }
+    
     // This must only be called on the streamPairThread,
     // e.g. from within the -stream:handleEvent: callback
     dispatch_sync(self.dataBufferIsolation, ^{


### PR DESCRIPTION
# Issue

High crash rate in recent release is indicating a possible issue with the line 236, where the `dispatch_sync` is called with `dataBufferIsolation` parameter. 

# Investigation

In the test project where the `dispatch_sync` is called with nil argument we received the same crash log as we see on user devices. Apparently if 2 writes are scheduled one after another right when the stream status is changing to error the first one is closing the connection and nullifying the `dataBufferIsolation`, and the second one is not falling in `outputStream.streamStatus == NSStreamStatusError`, since the value of `NSStreamStatusError` is 7, and if `outputStream` is nil then `outputStream.streamStatus` is resolved to 0.

# Solution

Add extra guard to check that the `dataBufferIsolation` exists.