### PR TITLE
Fix retain cycles and missing tear down calls

### DIFF
--- a/Source/Authentication/ZMAccessTokenHandler.m
+++ b/Source/Authentication/ZMAccessTokenHandler.m
@@ -56,7 +56,7 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
 
 @property (nonatomic) NSURL *baseURL;
 @property (nonatomic) ZMPersistentCookieStorage *cookieStorage;
-@property (nonatomic) id<ZMAccessTokenHandlerDelegate> delegate;
+@property (nonatomic, weak) id<ZMAccessTokenHandlerDelegate> delegate;
 
 @property (nonatomic) ZMExponentialBackoff *backoff;
 @property (nonatomic) NSOperationQueue *workQueue;
@@ -86,6 +86,10 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
         self.accessToken = initialAccessToken;
     }
     return self;
+}
+
+- (void)dealloc {
+    [self.backoff tearDown];
 }
 
 - (void)setAccessTokenRenewalFailureHandler:(ZMCompletionHandlerBlock)handler
@@ -118,10 +122,15 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
     _accessToken = accessToken;
     [self didChangeValueForKey:@"accessToken"];
     
+    id<ZMAccessTokenHandlerDelegate> delegate = self.delegate;
+    if(delegate == nil) {
+        return;
+    }
+    
     if (_accessToken != nil) {
-        [self.delegate handlerDidReceiveAccessToken:self];
+        [delegate handlerDidReceiveAccessToken:self];
     } else {
-        [self.delegate handlerDidClearAccessToken:self];
+        [delegate handlerDidClearAccessToken:self];
     }
 }
 

--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -19,25 +19,16 @@
 import UIKit
 import WireUtilities
 
-
-private var _instance : BackgroundActivityFactory? = BackgroundActivityFactory() // swift automatically dispatch_once make this thread safe
-
 @objc open class BackgroundActivityFactory: NSObject {
+    
+    private static let _instance : BackgroundActivityFactory = BackgroundActivityFactory()
     
     open var application : UIApplication? = nil
     open var mainGroupQueue : ZMSGroupQueue? = nil
     
     @objc open class func sharedInstance() -> BackgroundActivityFactory
     {
-        if _instance == nil {
-            _instance = BackgroundActivityFactory()
-        }
-        return _instance!
-    }
-    
-    @objc open class func tearDownInstance()
-    {
-        _instance = nil
+        return _instance
     }
     
     @objc open func backgroundActivity(withName name: String) -> ZMBackgroundActivity?

--- a/Source/PushChannel/ZMTransportPushChannel.m
+++ b/Source/PushChannel/ZMTransportPushChannel.m
@@ -96,6 +96,10 @@ ZM_EMPTY_ASSERTING_INIT();
     return self;
 }
 
+- (void)dealloc {
+    [self.scheduler tearDown];
+}
+
 - (void)setPushChannelConsumer:(id<ZMPushChannelConsumer>)consumer groupQueue:(id<ZMSGroupQueue>)groupQueue;
 {
     ZMLogInfo(@"Setting push channel consumer");

--- a/Source/URLSession/ZMServerTrust.m
+++ b/Source/URLSession/ZMServerTrust.m
@@ -45,7 +45,8 @@ static SecKeyRef publicKeyFromCertificateData(NSData *certificateData)
     }
     
     SecKeyRef key = SecCertificateCopyPublicKey(certificate);
-    
+    CFRelease(certificate);
+
     if (key == nil) {
         [NSException raise:NSInvalidArgumentException format:@"Error extracing pinned key from certificate"];
     }


### PR DESCRIPTION
After creating an instance of `ZMTransportSession`, performing one request, waiting for response and tearing it down, only one instance left: a singleton.

<img width="286" alt="screen shot 2017-07-18 at 17 59 01" src="https://user-images.githubusercontent.com/620000/28327115-d234e02c-6be2-11e7-841b-1cff40a03e4e.png">
