### PR TITLE
Fix memory leak in server trust verification

### DIFF
--- a/Source/URLSession/ZMServerTrust.m
+++ b/Source/URLSession/ZMServerTrust.m
@@ -112,13 +112,13 @@ BOOL verifyServerTrust(SecTrustRef const serverTrust, NSString *host)
 static SecKeyRef publicKeyAssociatedWithServerTrust(SecTrustRef const serverTrust)
 {
     SecKeyRef key = nil;
-    SecPolicyRef policy = SecPolicyCreateBasicX509();
+    __block SecPolicyRef policy = SecPolicyCreateBasicX509();
     
-    SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, 0); // leaf certificate
+    __block SecCertificateRef certificate = SecTrustGetCertificateAtIndex(serverTrust, 0); // leaf certificate
     
     SecCertificateRef certificatesCArray[] = { certificate};
     CFArrayRef certificates = CFArrayCreate(NULL, (const void **)certificatesCArray, 1, NULL);
-    SecTrustRef trust = NULL;
+    __block SecTrustRef trust = NULL;
     
     void(^finally)() = ^{
         if (certificates) {


### PR DESCRIPTION
It's all in the `__block`.

There is a "cleanup block" (the Obj-c version of Swift's `defer {}`), to make sure we release all variables in all conditional branches . However, the variables that are cleaned by the cleanup block are not declared `__block` so the block actually captures them by value when they are still not initialized, and when the block is executed, it does not release anything.

