### PR TITLE
Fix cookie label behaviour

### DIFF
--- a/Source/Authentication/ZMPersistentCookieStorage.m
+++ b/Source/Authentication/ZMPersistentCookieStorage.m
@@ -20,6 +20,7 @@
 @import Security;
 @import WireSystem;
 @import WireUtilities;
+@import UIKit;
 
 #import "ZMTLogging.h"
 #import "ZMPersistentCookieStorage.h"
@@ -91,7 +92,11 @@ static dispatch_queue_t isolationQueue()
 - (NSString *)cookieLabel
 {
     if (_cookieLabel == nil) {
-        _cookieLabel = [NSUUID UUID].UUIDString;
+        NSUUID *deviceIdentifier = [[UIDevice currentDevice] identifierForVendor];
+        if (deviceIdentifier == nil) {
+            deviceIdentifier = [NSUUID UUID];
+        }
+        _cookieLabel = deviceIdentifier.UUIDString;
     }
     return _cookieLabel;
 }


### PR DESCRIPTION
According to backend specifications we need to keep cookie label the same for all accounts on the device. This will prevent the situation when cookie label gets out of sync after force logout or logging in with a different method to an existing account.