### PR TITLE
Update tests to hit network for external host trust tests

### DIFF
--- a/Source/Public/WireTransport.h
+++ b/Source/Public/WireTransport.h
@@ -55,3 +55,7 @@ FOUNDATION_EXPORT const unsigned char TransportVersionString[];
 #import <WireTransport/ZMTaskIdentifier.h>
 #import <WireTransport/ZMRequestCancellation.h>
 #import <WireTransport/ZMPushChannel.h>
+
+
+// Private
+#import "ZMServerTrust.h"

--- a/Tests/Source/URLSession/TestTrustVerificator.swift
+++ b/Tests/Source/URLSession/TestTrustVerificator.swift
@@ -1,0 +1,44 @@
+//
+// Wire
+// Copyright (C) 2017 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import WireTransport
+
+@objc public class TestTrustVerificator: NSObject, URLSessionDelegate {
+
+    private var session: URLSession!
+    private let callback: (Bool) -> Void
+
+    public init(callback: @escaping (Bool) -> Void) {
+        self.callback = callback
+        super.init()
+        session = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+    }
+
+    public func urlSession(_ session: URLSession, didReceive challenge: URLAuthenticationChallenge, completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void) {
+        let protectionSpace = challenge.protectionSpace
+        guard protectionSpace.authenticationMethod == NSURLAuthenticationMethodServerTrust else { return callback(false) }
+        let trusted = verifyServerTrust(protectionSpace.serverTrust, protectionSpace.host)
+        callback(trusted)
+    }
+
+    @objc(verifyURL:) public func verify(url: URL) {
+        session.dataTask(with: url).resume()
+    }
+
+}

--- a/Tests/Source/URLSession/ZMServerTrustTests.m
+++ b/Tests/Source/URLSession/ZMServerTrustTests.m
@@ -18,12 +18,13 @@
 
 #import <XCTest/XCTest.h>
 #import "ZMServerTrust.h"
+#import "WireTransport_ios_tests-Swift.h"
 
 @import WireTesting;
 @import WireUtilities;
 
-@interface ZMServerTrustTests : ZMTBaseTest
 
+@interface ZMServerTrustTests : ZMTBaseTest
 @end
 
 @implementation ZMServerTrustTests
@@ -339,12 +340,19 @@
 - (void)testExternalHostWithValidCertificateIsTrusted
 {
     // given
-    SecTrustRef serverTrust = [self validTrustForExternalHost];
-    
+    XCTestExpectation *trustExpectation = [self expectationWithDescription:@"It should verify the server trust"];
+
+    TestTrustVerificator *trustVerificator = [[TestTrustVerificator alloc] initWithCallback:^(BOOL trusted){
+        if (trusted) {
+            [trustExpectation fulfill];
+        }
+    }]; 
+
+    // when
+    [trustVerificator verifyURL:[NSURL URLWithString:@"https://www.youtube.com"]];
+
     // then
-    XCTAssertTrue(verifyServerTrust(serverTrust, @"https://www.youtube.com"));
-    
-    CFRelease(serverTrust);
+    XCTAssert([self waitForCustomExpectationsWithTimeout:0.5]);
 }
 
 - (void)testExternalHostWithInvalidCertificateIsNotTrusted

--- a/WireTransport.xcodeproj/project.pbxproj
+++ b/WireTransport.xcodeproj/project.pbxproj
@@ -111,7 +111,7 @@
 		54CA15CB1B32F2C1008D3787 /* ZMTransportSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 54CA15441B32F2C1008D3787 /* ZMTransportSession.m */; };
 		54CA15CD1B32F2C1008D3787 /* ZMTransportSessionErrorCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 54CA15451B32F2C1008D3787 /* ZMTransportSessionErrorCode.h */; };
 		54CA15CF1B32F2C1008D3787 /* ZMReachability.m in Sources */ = {isa = PBXBuildFile; fileRef = 54CA15471B32F2C1008D3787 /* ZMReachability.m */; };
-		54CA15D11B32F2C1008D3787 /* ZMServerTrust.h in Headers */ = {isa = PBXBuildFile; fileRef = 54CA15481B32F2C1008D3787 /* ZMServerTrust.h */; };
+		54CA15D11B32F2C1008D3787 /* ZMServerTrust.h in Headers */ = {isa = PBXBuildFile; fileRef = 54CA15481B32F2C1008D3787 /* ZMServerTrust.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		54CA15D31B32F2C1008D3787 /* ZMServerTrust.m in Sources */ = {isa = PBXBuildFile; fileRef = 54CA15491B32F2C1008D3787 /* ZMServerTrust.m */; };
 		54CA15D51B32F2C1008D3787 /* ZMURLSession+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 54CA154A1B32F2C1008D3787 /* ZMURLSession+Internal.h */; };
 		54CA15D71B32F2C1008D3787 /* ZMURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 54CA154B1B32F2C1008D3787 /* ZMURLSession.m */; };
@@ -121,6 +121,7 @@
 		54EA3E6D1BEA65B80071592B /* Fakes.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EA3E6C1BEA65B80071592B /* Fakes.m */; };
 		871667FE1BB2CD1E009C6EEA /* ZMKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 871667FC1BB2CD1E009C6EEA /* ZMKeychain.m */; };
 		871668001BB2CD2A009C6EEA /* ZMKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 871667FF1BB2CD2A009C6EEA /* ZMKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		AF9D8F9E1F20D9B700ABF225 /* TestTrustVerificator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9D8F9C1F20D99500ABF225 /* TestTrustVerificator.swift */; };
 		BF3A7A641D8AD5430034FF40 /* SwiftStructs+TransportEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3A7A631D8AD5430034FF40 /* SwiftStructs+TransportEncoding.swift */; };
 		BF3A7A6B1D8C01D30034FF40 /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF3A7A6A1D8C01D30034FF40 /* CoreImage.framework */; };
 		BF3A7A6C1D8C04550034FF40 /* WireTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BCA71B1F35DF00232589 /* WireTransport.framework */; };
@@ -345,6 +346,7 @@
 		54EA3E6C1BEA65B80071592B /* Fakes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Fakes.m; sourceTree = "<group>"; };
 		871667FC1BB2CD1E009C6EEA /* ZMKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMKeychain.m; sourceTree = "<group>"; };
 		871667FF1BB2CD2A009C6EEA /* ZMKeychain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMKeychain.h; sourceTree = "<group>"; };
+		AF9D8F9C1F20D99500ABF225 /* TestTrustVerificator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTrustVerificator.swift; sourceTree = "<group>"; };
 		BF3A7A631D8AD5430034FF40 /* SwiftStructs+TransportEncoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftStructs+TransportEncoding.swift"; sourceTree = "<group>"; };
 		BF3A7A6A1D8C01D30034FF40 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/CoreImage.framework; sourceTree = DEVELOPER_DIR; };
 		BF453F191CC6377200403E1C /* ZMRequestCancellation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMRequestCancellation.h; sourceTree = "<group>"; };
@@ -624,6 +626,7 @@
 				546E89DC1B33015000DD1042 /* ZMURLSessionTests.m */,
 				BFEC39661CC6423700591F36 /* ZMTaskIdentifierTests.m */,
 				16B6859B1EC1BBF00055BEA3 /* ZMServerTrustTests.m */,
+				AF9D8F9C1F20D99500ABF225 /* TestTrustVerificator.swift */,
 				5431AC001DB4C8330040343C /* RequestLoopDetectionTests.swift */,
 			);
 			path = URLSession;
@@ -1105,6 +1108,7 @@
 				546E89DF1B33015000DD1042 /* ZMAccessTokenTests.m in Sources */,
 				F9C4317E1CD7ADF300A8542F /* ZMKeychainTests.m in Sources */,
 				546E89FF1B33015000DD1042 /* ZMTransportCodecTests.m in Sources */,
+				AF9D8F9E1F20D9B700ABF225 /* TestTrustVerificator.swift in Sources */,
 				BFEC39671CC6423700591F36 /* ZMTaskIdentifierTests.m in Sources */,
 				546E89F11B33015000DD1042 /* ZMWebSocketHandshakeTests.m in Sources */,
 				0928E2051BA023A30057232E /* NSData_MultipartTests.m in Sources */,


### PR DESCRIPTION
# What's in this PR?

The trust tests for external hosts were failing because of outdated certificate fixtures which we store locally in order to not have to hit the network. However some of these certificates were updated at the beginning of July and will expire again in October. Because of these short lived certificates we now hit the network when testing checking the trust of external hosts.