### PR TITLE
Guard against invalidated session

### DIFF
--- a/Source/URLSession/ZMURLSession.m
+++ b/Source/URLSession/ZMURLSession.m
@@ -464,6 +464,11 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
 {
     NSURLSessionTask *task;
     
+    if (self.tornDown) {
+        ZMLogError(@"%@: cannot create the task for request (%@), isTornDown = %d", self, request, self.tornDown);
+        return nil;
+    }
+    
     if (nil != transportRequest.fileUploadURL) {
         RequireString(self.isBackgroundSession, "File uploads need to set 'forceToBackgroundSession' on the request");
         task = [self.backingSession uploadTaskWithRequest:request fromFile:transportRequest.fileUploadURL];


### PR DESCRIPTION
# Issue

Crash happens when we try to schedule the request on the torn down (invalidated) URL session.

Reference: https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/URLLoadingSystem/NSURLSessionConcepts/NSURLSessionConcepts.html