### PR TITLE
fixed a bug where ZMReachability's tearDown wasn't called from ZMTransportSession

### DIFF
--- a/Source/Public/ZMReachability.h
+++ b/Source/Public/ZMReachability.h
@@ -60,7 +60,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ZMReachabilityObserver <NSObject>
 
-- (void)reachabilityDidChange:(id<ReachabilityProvider>)reachability;
+- (void)reachabilityDidChange:(id<ReachabilityProvider,ReachabilityTearDown>)reachability;
 
 @end
 

--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ZMKeyValueStore;
 @protocol ZMPushChannel;
 @protocol ReachabilityProvider;
+@protocol ReachabilityTearDown;
 @class ZMURLSessionSwitch;
 @class ZMTransportRequest;
 
@@ -74,12 +75,12 @@ extern NSString * const ZMTransportSessionNewRequestAvailableNotification;
 @property (nonatomic, assign) NSInteger maximumConcurrentRequests;
 @property (nonatomic, readonly) ZMPersistentCookieStorage *cookieStorage;
 @property (nonatomic, copy) void (^requestLoopDetectionCallback)(NSString*);
-@property (nonatomic, readonly) id<ReachabilityProvider> reachability;
+@property (nonatomic, readonly) id<ReachabilityProvider,ReachabilityTearDown> reachability;
 
 - (instancetype)initWithBaseURL:(NSURL *)baseURL
                    websocketURL:(NSURL *)websocketURL
                   cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
-                   reachability:(id<ReachabilityProvider>)reachability
+                   reachability:(id<ReachabilityProvider,ReachabilityTearDown>)reachability
              initialAccessToken:(nullable ZMAccessToken *)initialAccessToken
       sharedContainerIdentifier:(nullable NSString *)sharedContainerIdentifier;
 

--- a/Source/TransportSession/ZMTransportSession+internal.h
+++ b/Source/TransportSession/ZMTransportSession+internal.h
@@ -36,7 +36,7 @@
 
 - (instancetype)initWithURLSessionSwitch:(ZMURLSessionSwitch *)URLSessionSwitch
                         requestScheduler:(ZMTransportRequestScheduler *)requestScheduler
-                            reachability:(id<ReachabilityProvider>)reachability
+                            reachability:(id<ReachabilityProvider,ReachabilityTearDown>)reachability
                                    queue:(NSOperationQueue *)queue
                                    group:(ZMSDispatchGroup *)group
                                  baseURL:(NSURL *)baseURL

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -93,7 +93,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 @property (nonatomic) NSMutableDictionary <NSString *, dispatch_block_t> *completionHandlerBySessionID;
 
 @property (nonatomic) id<RequestRecorder> requestLoopDetection;
-@property (nonatomic, readwrite) id<ReachabilityProvider> reachability;
+@property (nonatomic, readwrite) id<ReachabilityProvider,ReachabilityTearDown> reachability;
 
 @end
 
@@ -170,7 +170,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 - (instancetype)initWithBaseURL:(NSURL *)baseURL
                    websocketURL:(NSURL *)websocketURL
                   cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
-                   reachability:(id<ReachabilityProvider>)reachability
+                   reachability:(id<ReachabilityProvider,ReachabilityTearDown>)reachability
              initialAccessToken:(ZMAccessToken *)initialAccessToken
       sharedContainerIdentifier:(NSString *)sharedContainerIdentifier
 {
@@ -202,7 +202,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 - (instancetype)initWithURLSessionSwitch:(ZMURLSessionSwitch *)URLSessionSwitch
                         requestScheduler:(ZMTransportRequestScheduler *)requestScheduler
-                            reachability:(id<ReachabilityProvider>)reachability
+                            reachability:(id<ReachabilityProvider,ReachabilityTearDown>)reachability
                                    queue:(NSOperationQueue *)queue
                                    group:(ZMSDispatchGroup *)group
                                  baseURL:(NSURL *)baseURL
@@ -225,7 +225,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 - (instancetype)initWithURLSessionSwitch:(ZMURLSessionSwitch *)URLSessionSwitch
                         requestScheduler:(ZMTransportRequestScheduler *)requestScheduler
-                            reachability:(id<ReachabilityProvider>)reachability
+                            reachability:(id<ReachabilityProvider,ReachabilityTearDown>)reachability
                                    queue:(NSOperationQueue *)queue
                                    group:(ZMSDispatchGroup *)group
                                  baseURL:(NSURL *)baseURL
@@ -291,6 +291,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     [self.workGroup enter];
     [self.workQueue addOperationWithBlock:^{
         [self.urlSessionSwitch tearDown];
+        [self.reachability tearDown];
         [self.workGroup leave];
     }];
 }
@@ -749,7 +750,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 @implementation ZMTransportSession (ReachabilityObserver)
 
-- (void)reachabilityDidChange:(id<ReachabilityProvider>)reachability;
+- (void)reachabilityDidChange:(id<ReachabilityProvider,ReachabilityTearDown>)reachability;
 {
     ZMLogInfo(@"reachabilityDidChange -> mayBeReachable = %@", reachability.mayBeReachable ? @"YES" : @"NO");
     [self.requestScheduler reachabilityDidChange:reachability];

--- a/Source/URLSession/ZMReachability.m
+++ b/Source/URLSession/ZMReachability.m
@@ -1,4 +1,4 @@
-// 
+//
 // Wire
 // Copyright (C) 2016 Wire Swiss GmbH
 // 
@@ -28,7 +28,7 @@
 static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 
 
-@interface ZMReachability() <ReachabilityProvider>
+@interface ZMReachability() <ReachabilityProvider,ReachabilityTearDown>
 {
     int32_t _tornDown;
 }

--- a/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -50,7 +50,7 @@ private class MockURLSession: SessionProtocol {
 
 }
 
-private class MockReachability: NSObject, ReachabilityProvider {
+private class MockReachability: NSObject, ReachabilityProvider, ReachabilityTearDown {
     let mayBeReachable = true
     let isMobileConnection = true
     let oldMayBeReachable = true

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.swift
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.swift
@@ -19,9 +19,11 @@
 import Foundation
 import WireTransport
 
-@objc public class FakeReachability: NSObject, ReachabilityProvider {
+@objc public class FakeReachability: NSObject, ReachabilityProvider, ReachabilityTearDown {
     public var mayBeReachable: Bool = true
     public var isMobileConnection: Bool = true
     public var oldMayBeReachable: Bool = true
     public var oldIsMobileConnection: Bool = true
+    
+    public func tearDown() { }
 }


### PR DESCRIPTION
In the `tearDown()` method of the `ZMTransportSession` class, the respective `tearDown()` method of the `ZMReachability` class wasn't called, causing a wrong deallocation of resources and then a crash.