### PR TITLE
Dont tear down reachability

### DIFF
--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -291,7 +291,6 @@ static NSInteger const DefaultMaximumRequests = 6;
     [self.workGroup enter];
     [self.workQueue addOperationWithBlock:^{
         [self.urlSessionSwitch tearDown];
-        [self.reachability tearDown];
         [self.workGroup leave];
     }];
 }


### PR DESCRIPTION
The reachability are shared between the unauthentication session and all user sessions, therefore it's should not be torn down.