### PR TITLE
Fix observing of reachability

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "wireapp/ocmock" "v3.3.2"
 github "wireapp/wire-ios-system" "18.2.2"
 github "wireapp/wire-ios-testing" "12.1.0"
-github "wireapp/wire-ios-utilities" "17.1.1"
+github "wireapp/wire-ios-utilities" "17.2.0"

--- a/Source/Public/ZMReachability.h
+++ b/Source/Public/ZMReachability.h
@@ -23,6 +23,9 @@ NS_ASSUME_NONNULL_BEGIN
 @import WireSystem;
 
 @protocol ZMReachabilityObserver;
+@protocol ReachabilityProvider;
+
+typedef void (^ReachabilityObserverBlock)(id<ReachabilityProvider> provider);
 
 @protocol ReachabilityProvider
 
@@ -30,6 +33,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (atomic, readonly) BOOL isMobileConnection;
 @property (atomic, readonly) BOOL oldMayBeReachable;
 @property (atomic, readonly) BOOL oldIsMobileConnection;
+
+/// Register to observe when reachability status changes.
+/// Returns a token which should be retained as long as the observer should be active.
+- (id)addReachabilityObserver:(id<ZMReachabilityObserver>)observer queue:(nullable NSOperationQueue *)queue;
+- (id)addReachabilityObserverOnQueue:(nullable NSOperationQueue *)queue block:(ReachabilityObserverBlock)block;
 
 @end
 
@@ -43,7 +51,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface ZMReachability : NSObject <ReachabilityProvider, ReachabilityTearDown>
 
 /// Calls to the observer will always happen on the specified @c observerQueue . All work will be added to the @c group
-- (instancetype)initWithServerNames:(NSArray *)names observer:(id<ZMReachabilityObserver> _Nullable)observer queue:(NSOperationQueue *)observerQueue group:(ZMSDispatchGroup *)group;
+- (instancetype)initWithServerNames:(NSArray *)names group:(ZMSDispatchGroup *)group;
 
 - (void)tearDown;
 
@@ -60,7 +68,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol ZMReachabilityObserver <NSObject>
 
-- (void)reachabilityDidChange:(id<ReachabilityProvider,ReachabilityTearDown>)reachability;
+- (void)reachabilityDidChange:(id<ReachabilityProvider>)reachability;
 
 @end
 

--- a/Source/Public/ZMReachability.h
+++ b/Source/Public/ZMReachability.h
@@ -37,6 +37,9 @@ typedef void (^ReachabilityObserverBlock)(id<ReachabilityProvider> provider);
 /// Register to observe when reachability status changes.
 /// Returns a token which should be retained as long as the observer should be active.
 - (id)addReachabilityObserver:(id<ZMReachabilityObserver>)observer queue:(nullable NSOperationQueue *)queue;
+
+/// Register to observe when reachability status changes.
+/// Returns a token which should be retained as long as the observer should be active.
 - (id)addReachabilityObserverOnQueue:(nullable NSOperationQueue *)queue block:(ReachabilityObserverBlock)block;
 
 @end

--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -54,7 +54,6 @@ typedef NS_ENUM(NSInteger, ZMTransportSessionErrorCode) {
     ZMTransportSessionErrorCodeTryAgainLater, ///< c.f. @code -[NSError isTryAgainLaterError] @endcode
 };
 
-extern NSString * const ZMTransportSessionReachabilityChangedNotificationName;
 extern NSString * const ZMTransportSessionNewRequestAvailableNotification;
 
 /// Return type for an enqueue operation

--- a/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -51,12 +51,18 @@ private class MockURLSession: SessionProtocol {
 }
 
 private class MockReachability: NSObject, ReachabilityProvider, ReachabilityTearDown {
+
     let mayBeReachable = true
     let isMobileConnection = true
     let oldMayBeReachable = true
     let oldIsMobileConnection = true
     
     func tearDown() {}
+    func add(_ observer: ZMReachabilityObserver, queue: OperationQueue?) -> Any { return NSObject() }
+    func addReachabilityObserver(on queue: OperationQueue?, block: @escaping ReachabilityObserverBlock) -> Any {
+        return NSObject()
+    }
+    
 }
 
 final class UnauthenticatedTransportSessionTests: ZMTBaseTest {

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -2169,6 +2169,11 @@ static XCTestCase *currentTestCase;
     XCTAssert([self waitForCustomExpectationsWithTimeout:0.5]);
 }
 
+- (void)testItRegistersAsObserverOfReachability
+{
+    XCTAssertEqual(self.reachability.observerCount, 1);
+}
+
 - (void)testThatItCallsDidReceiveDataOnTheReachabilityDelegate
 {
     // given
@@ -2201,30 +2206,6 @@ static XCTestCase *currentTestCase;
     
     // then
     [observer verify];
-}
-
-- (void)testThatItSendsTransportSessionReachabilityChangeNotificationOnReachabilityChanges
-{
-    // expect
-    [self expectationForNotification:ZMTransportSessionReachabilityChangedNotificationName object:nil handler:nil];
-    
-    // when
-    [self.sut reachabilityDidChange:self.sut.reachability];
-    XCTAssert([self waitForCustomExpectationsWithTimeout:0.5]);
-}
-
-- (void)testThatItSendsTransportSessionReachabilityChangeNotificationOnReachabilityChangesToOffline
-{
-    // given
-    id reachbilityMock = [OCMockObject mockForClass:[ZMReachability class]];
-    [[[reachbilityMock stub] andReturnValue:@NO] mayBeReachable];
-
-    // expect
-    [self expectationForNotification:ZMTransportSessionReachabilityChangedNotificationName object:nil handler:nil];
-
-    // when
-    [self.sut reachabilityDidChange:reachbilityMock];
-    XCTAssert([self waitForCustomExpectationsWithTimeout:0.5]);
 }
 
 - (void)testThatWhenSettingTheNetworkStateDelegateItIsCalledWithTheCurrentStatus

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.swift
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.swift
@@ -20,6 +20,17 @@ import Foundation
 import WireTransport
 
 @objc public class FakeReachability: NSObject, ReachabilityProvider, ReachabilityTearDown {
+    
+    public var observerCount = 0
+    public func add(_ observer: ZMReachabilityObserver, queue: OperationQueue?) -> Any {
+        observerCount += 1
+        return NSObject()
+    }
+    
+    public func addReachabilityObserver(on queue: OperationQueue?, block: @escaping ReachabilityObserverBlock) -> Any {
+        return NSObject()
+    }
+
     public var mayBeReachable: Bool = true
     public var isMobileConnection: Bool = true
     public var oldMayBeReachable: Bool = true


### PR DESCRIPTION
Since we now will have multiple transport sessions running in parallel with one shared reachability
object, it will need to support having multiple observers.