### PR TITLE
Mixed background sessions

### DIFF
--- a/Source/Authentication/ZMPersistentCookieStorage.m
+++ b/Source/Authentication/ZMPersistentCookieStorage.m
@@ -48,7 +48,6 @@ static dispatch_queue_t isolationQueue()
 @interface ZMPersistentCookieStorage ()
 
 @property (nonatomic, readonly) NSString *serverName;
-@property (nonatomic, readonly) NSUUID *userIdentifier;
 
 @end
 

--- a/Source/Public/ZMPersistentCookieStorage.h
+++ b/Source/Public/ZMPersistentCookieStorage.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)deleteKeychainItems;
 
 @property (nonatomic, nullable) NSData *authenticationCookieData;
+@property (nonatomic, readonly) NSUUID *userIdentifier;
 
 @end
 

--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -73,6 +73,7 @@ extern NSString * const ZMTransportSessionNewRequestAvailableNotification;
 @property (nonatomic, readonly) NSOperationQueue *workQueue;
 @property (nonatomic, assign) NSInteger maximumConcurrentRequests;
 @property (nonatomic, readonly) ZMPersistentCookieStorage *cookieStorage;
+@property (nonatomic, readonly) ZMURLSessionSwitch *urlSessionSwitch;
 @property (nonatomic, copy) void (^requestLoopDetectionCallback)(NSString*);
 @property (nonatomic, readonly) id<ReachabilityProvider,ReachabilityTearDown> reachability;
 

--- a/Source/Public/ZMURLSession.h
+++ b/Source/Public/ZMURLSession.h
@@ -28,6 +28,8 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ZMURLSessionDelegate;
 
 extern NSString * const ZMURLSessionBackgroundIdentifier;
+extern NSString * const ZMURLSessionForegroundIdentifier;
+extern NSString * const ZMURLSessionVoipIdentifier;
 
 @interface ZMURLSession : NSObject
 

--- a/Source/URLSession/ZMURLSession.m
+++ b/Source/URLSession/ZMURLSession.m
@@ -85,6 +85,7 @@ ZM_EMPTY_ASSERTING_INIT();
     ZMURLSession *session = [[ZMURLSession alloc] initWithDelegate:delegate identifier:identifier];
     if(session) {
         session->_backingSession = [NSURLSession sessionWithConfiguration:configuration delegate:session delegateQueue:queue];
+        session->_backingSession.sessionDescription = identifier;
     }
     return session;
 }

--- a/Source/URLSession/ZMURLSession.m
+++ b/Source/URLSession/ZMURLSession.m
@@ -37,6 +37,8 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK_LOW_LEVEL;
 
 static NSUInteger const ZMTransportDecreasedProgressCancellationLeeway = 1024 * 2;
 NSString * const ZMURLSessionBackgroundIdentifier = @"background-session";
+NSString * const ZMURLSessionForegroundIdentifier = @"foreground-session";
+NSString * const ZMURLSessionVoipIdentifier = @"voip-session";
 
 @interface ZMURLSession ()
 

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.swift
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.swift
@@ -18,6 +18,7 @@
 
 import Foundation
 import WireTransport
+import WireTesting
 
 @objc public class FakeReachability: NSObject, ReachabilityProvider, ReachabilityTearDown {
     
@@ -38,3 +39,68 @@ import WireTransport
     
     public func tearDown() { }
 }
+
+class ZMTransportSessionTests_Initialization: ZMTBaseTest {
+    var userIdentifier: UUID!
+    var containerIdentifier: String!
+    var serverName: String!
+    var baseURL: URL!
+    var websocketURL: URL!
+    var cookieStorage: ZMPersistentCookieStorage!
+    var reachability: FakeReachability!
+    var sut: ZMTransportSession!
+    
+    override func setUp() {
+        super.setUp()
+        userIdentifier = UUID()
+        containerIdentifier = "some.bundle.id"
+        serverName = "https://example.com"
+        baseURL = URL(string: serverName)!
+        websocketURL = URL(string: serverName)!.appendingPathComponent("websocket")
+        cookieStorage = ZMPersistentCookieStorage(forServerName: serverName, userIdentifier: userIdentifier)
+        reachability = FakeReachability()
+        sut = ZMTransportSession(baseURL: baseURL, websocketURL: baseURL, cookieStorage: cookieStorage, reachability: reachability, initialAccessToken: nil, sharedContainerIdentifier: containerIdentifier)
+    }
+    
+    override func tearDown() {
+        userIdentifier = nil
+        containerIdentifier = nil
+        serverName = nil
+        baseURL = nil
+        websocketURL = nil
+        cookieStorage = nil
+        reachability = nil
+        sut.tearDown()
+        sut = nil
+        super.tearDown()
+    }
+    
+    func check(identifier: String?, contains items: [String], file: StaticString = #file, line: UInt = #line) {
+        guard let identifier = identifier else { XCTFail("identifier should not be nil", file: file, line: line); return }
+        for item in items {
+            XCTAssert(identifier.contains(item), "[\(identifier)] should contain [\(item)]", file: file, line: line)
+        }
+    }
+    
+    func testThatItConfiguresSessionsCorrectly() {
+        // given
+        let userID = userIdentifier.transportString()
+        let voipSession = sut.urlSessionSwitch.voipSession
+        let foregroundSession = sut.urlSessionSwitch.foregroundSession
+        let backgroundSession = sut.urlSessionSwitch.backgroundSession
+
+        // then
+        check(identifier: voipSession.identifier, contains: [ZMURLSessionVoipIdentifier, userID])
+        
+        check(identifier: foregroundSession.identifier, contains: [ZMURLSessionForegroundIdentifier, userID])
+        
+        check(identifier: backgroundSession.identifier, contains: [ZMURLSessionBackgroundIdentifier, userID])
+        let backgroundConfiguration = backgroundSession.configuration
+        check(identifier: backgroundConfiguration.identifier, contains: [userID])
+        XCTAssertEqual(backgroundConfiguration.sharedContainerIdentifier, containerIdentifier)
+        
+        XCTAssertEqual(Set<String>([voipSession.identifier, foregroundSession.identifier, backgroundSession.identifier]).count, 3, "All identifiers should be unique")
+    }
+    
+}
+


### PR DESCRIPTION
## Problem
With multiple accounts logged in the image sent to inactive account would not be downloaded. 

## Reason
Image downloading is always dispatched through background `URLSession`. With multiple accounts there are multiple background sessions. So in some cases the `ZMURLSession` would enqueue the request to the wrong background session. The request would still go through, but completion blocks would not get called.

## Solution
Add user identifier to background session identifier and few more places to help debugging.
