### PR TITLE
Remove unused calling related events

### DIFF
--- a/Source/Public/ZMUpdateEvent.h
+++ b/Source/Public/ZMUpdateEvent.h
@@ -41,16 +41,6 @@ typedef NS_ENUM(NSUInteger, ZMUpdateEventType) {
     
     ZMUpdateEventUnknown = 0,
     
-    ZMUpdateEventCallCandidatesAdd,
-    ZMUpdateEventCallCandidatesUpdate,
-    ZMUpdateEventCallDeviceInfo,
-    ZMUpdateEventCallFlowActive,
-    ZMUpdateEventCallFlowAdd,
-    ZMUpdateEventCallFlowDelete,
-    ZMUpdateEventCallState,
-    ZMUpdateEventCallInfo ZM_DEPRECATED("Use ZMUpdateEventCallState"), ///< Deprecated. Should not be used
-    ZMUpdateEventCallParticipants,
-    ZMUpdateEventCallRemoteSDP,
     ZMUpdateEventConversationAssetAdd,
     ZMUpdateEventConversationConnectRequest,
     ZMUpdateEventConversationCreate,
@@ -64,9 +54,6 @@ typedef NS_ENUM(NSUInteger, ZMUpdateEventType) {
     ZMUpdateEventConversationOtrAssetAdd,
     ZMUpdateEventConversationRename,
     ZMUpdateEventConversationTyping,
-    ZMUpdateEventConversationVoiceChannel,
-    ZMUpdateEventConversationVoiceChannelActivate,
-    ZMUpdateEventConversationVoiceChannelDeactivate,
     ZMUpdateEventUserConnection,
     ZMUpdateEventUserNew,
     ZMUpdateEventUserUpdate,
@@ -98,9 +85,6 @@ typedef NS_ENUM(NSUInteger, ZMUpdateEventType) {
 
 /// True if the event will not appear in the notification stream
 @property (nonatomic, readonly) BOOL isTransient;
-
-/// True if the event type concerns calling flows
-@property (nonatomic, readonly) BOOL isFlowEvent;
 
 /// True if the event contains cryptobox-encrypted data
 @property (nonatomic, readonly) BOOL isEncrypted;

--- a/Source/TransportEncoding/ZMUpdateEvent.m
+++ b/Source/TransportEncoding/ZMUpdateEvent.m
@@ -168,16 +168,6 @@ struct TypeMap {
     CFStringRef name;
     ZMUpdateEventType type;
 } const TypeMapping[] = {
-    { CFSTR("call.device-info"), ZMUpdateEventCallDeviceInfo },
-    { CFSTR("call.flow-active"), ZMUpdateEventCallFlowActive },
-    { CFSTR("call.flow-add"), ZMUpdateEventCallFlowAdd },
-    { CFSTR("call.flow-delete"), ZMUpdateEventCallFlowDelete },
-    { CFSTR("call.info"), ZM_ALLOW_DEPRECATED(ZMUpdateEventCallInfo) },
-    { CFSTR("call.participants"), ZMUpdateEventCallParticipants },
-    { CFSTR("call.remote-candidates-add"), ZMUpdateEventCallCandidatesAdd },
-    { CFSTR("call.remote-candidates-update"), ZMUpdateEventCallCandidatesUpdate },
-    { CFSTR("call.remote-sdp"), ZMUpdateEventCallRemoteSDP },
-    { CFSTR("call.state"), ZMUpdateEventCallState },
     { CFSTR("conversation.asset-add"), ZMUpdateEventConversationAssetAdd },
     { CFSTR("conversation.connect-request"), ZMUpdateEventConversationConnectRequest },
     { CFSTR("conversation.create"), ZMUpdateEventConversationCreate },
@@ -191,9 +181,6 @@ struct TypeMap {
     { CFSTR("conversation.otr-asset-add"), ZMUpdateEventConversationOtrAssetAdd },
     { CFSTR("conversation.rename"), ZMUpdateEventConversationRename },
     { CFSTR("conversation.typing"), ZMUpdateEventConversationTyping },
-    { CFSTR("conversation.voice-channel"), ZMUpdateEventConversationVoiceChannel },
-    { CFSTR("conversation.voice-channel-activate"), ZMUpdateEventConversationVoiceChannelActivate },
-    { CFSTR("conversation.voice-channel-deactivate"), ZMUpdateEventConversationVoiceChannelDeactivate },
     { CFSTR("user.connection"), ZMUpdateEventUserConnection },
     { CFSTR("user.new"), ZMUpdateEventUserNew },
     { CFSTR("user.push-remove"), ZMUpdateEventUserPushRemove },
@@ -236,57 +223,6 @@ struct TypeMap {
     NSString *type = transportData[@"type"];
     self.type = [[self class] updateEventTypeForEventTypeString:type];
     return (self.type != ZMUpdateEventUnknown);
-}
-
-- (BOOL)isFlowEvent;
-{
-    switch (self.type) {
-        case ZMUpdateEventCallCandidatesAdd:
-        case ZMUpdateEventCallCandidatesUpdate:
-        case ZMUpdateEventCallFlowActive:
-        case ZMUpdateEventCallFlowAdd:
-        case ZMUpdateEventCallFlowDelete:
-        case ZMUpdateEventCallRemoteSDP:
-            return YES;
-        case ZMUpdateEventUnknown:
-        case ZMUpdateEventCallParticipants:
-        case ZM_ALLOW_DEPRECATED(ZMUpdateEventCallInfo):
-        case ZMUpdateEventCallDeviceInfo:
-        case ZMUpdateEventCallState:
-        case ZMUpdateEventConversationAssetAdd:
-        case ZMUpdateEventConversationConnectRequest:
-        case ZMUpdateEventConversationCreate:
-        case ZMUpdateEventConversationKnock:
-        case ZMUpdateEventConversationMemberJoin:
-        case ZMUpdateEventConversationMemberLeave:
-        case ZMUpdateEventConversationMemberUpdate:
-        case ZMUpdateEventConversationMessageAdd:
-        case ZMUpdateEventConversationClientMessageAdd:
-        case ZMUpdateEventConversationOtrMessageAdd:
-        case ZMUpdateEventConversationOtrAssetAdd:
-        case ZMUpdateEventConversationRename:
-        case ZMUpdateEventConversationTyping:
-        case ZMUpdateEventConversationVoiceChannel:
-        case ZMUpdateEventConversationVoiceChannelActivate:
-        case ZMUpdateEventConversationVoiceChannelDeactivate:
-        case ZMUpdateEventUserConnection:
-        case ZMUpdateEventUserNew:
-        case ZMUpdateEventUserUpdate:
-        case ZMUpdateEventUserPushRemove:
-        case ZMUpdateEventUserContactJoin:
-        case ZMUpdateEventUserClientAdd:
-        case ZMUpdateEventUserClientRemove:
-        case ZMUpdateEventTeamCreate:
-        case ZMUpdateEventTeamDelete:
-        case ZMUpdateEventTeamUpdate:
-        case ZMUpdateEventTeamMemberJoin:
-        case ZMUpdateEventTeamMemberLeave:
-        case ZMUpdateEventTeamMemberUpdate:
-        case ZMUpdateEventTeamConversationCreate:
-        case ZMUpdateEventTeamConversationDelete:
-        case ZMUpdateEvent_LAST:
-            return NO;
-    }
 }
 
 - (BOOL)isEncrypted
@@ -353,8 +289,4 @@ struct TypeMap {
             self.debugInformation];
 }
 
-
 @end
-
-
-

--- a/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
+++ b/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
@@ -34,16 +34,6 @@
 - (NSDictionary *)typesMapping
 {
     return @{
-             @"call.device-info" : @(ZMUpdateEventCallDeviceInfo),
-             @"call.flow-active" : @(ZMUpdateEventCallFlowActive),
-             @"call.flow-add" : @(ZMUpdateEventCallFlowAdd),
-             @"call.flow-delete" : @(ZMUpdateEventCallFlowDelete),
-             @"call.info" : ZM_ALLOW_DEPRECATED(@(ZMUpdateEventCallInfo)),
-             @"call.participants": @(ZMUpdateEventCallParticipants),
-             @"call.remote-candidates-add" : @(ZMUpdateEventCallCandidatesAdd),
-             @"call.remote-candidates-update" : @(ZMUpdateEventCallCandidatesUpdate),
-             @"call.remote-sdp" : @(ZMUpdateEventCallRemoteSDP),
-             @"call.state" : @(ZMUpdateEventCallState),
              @"conversation.asset-add" : @(ZMUpdateEventConversationAssetAdd),
              @"conversation.connect-request" : @(ZMUpdateEventConversationConnectRequest),
              @"conversation.create" : @(ZMUpdateEventConversationCreate),
@@ -57,9 +47,6 @@
              @"conversation.otr-asset-add" : @(ZMUpdateEventConversationOtrAssetAdd),
              @"conversation.rename" : @(ZMUpdateEventConversationRename),
              @"conversation.typing" : @(ZMUpdateEventConversationTyping),
-             @"conversation.voice-channel" : @(ZMUpdateEventConversationVoiceChannel),
-             @"conversation.voice-channel-activate" : @(ZMUpdateEventConversationVoiceChannelActivate),
-             @"conversation.voice-channel-deactivate" : @(ZMUpdateEventConversationVoiceChannelDeactivate),
              @"user.connection" : @(ZMUpdateEventUserConnection),
              @"user.new" : @(ZMUpdateEventUserNew),
              @"user.push-remove" : @(ZMUpdateEventUserPushRemove),
@@ -645,78 +632,6 @@
     
     // then
     XCTAssertTrue(event.isTransient);
-}
-
-
-- (void)testThatItDetectsFlowEvents;
-{
-    for (ZMUpdateEventType type = ZMUpdateEventUnknown; type < ZMUpdateEvent_LAST; type++) {
-        // given
-        BOOL expected = NO;
-        switch (type) {
-            case ZMUpdateEventUnknown:
-                continue;
-            case ZMUpdateEventCallCandidatesAdd:
-            case ZMUpdateEventCallCandidatesUpdate:
-            case ZMUpdateEventCallFlowActive:
-            case ZMUpdateEventCallFlowAdd:
-            case ZMUpdateEventCallFlowDelete:
-            case ZMUpdateEventCallRemoteSDP:
-                expected = YES;
-                break;
-            case ZMUpdateEventCallParticipants:
-            case ZM_ALLOW_DEPRECATED(ZMUpdateEventCallInfo):
-            case ZMUpdateEventCallDeviceInfo:
-            case ZMUpdateEventCallState:
-            case ZMUpdateEventConversationAssetAdd:
-            case ZMUpdateEventConversationConnectRequest:
-            case ZMUpdateEventConversationCreate:
-            case ZMUpdateEventConversationKnock:
-            case ZMUpdateEventConversationMemberJoin:
-            case ZMUpdateEventConversationMemberLeave:
-            case ZMUpdateEventConversationMemberUpdate:
-            case ZMUpdateEventConversationMessageAdd:
-            case ZMUpdateEventConversationClientMessageAdd:
-            case ZMUpdateEventConversationOtrMessageAdd:
-            case ZMUpdateEventConversationOtrAssetAdd:
-            case ZMUpdateEventConversationRename:
-            case ZMUpdateEventConversationTyping:
-            case ZMUpdateEventConversationVoiceChannel:
-            case ZMUpdateEventConversationVoiceChannelActivate:
-            case ZMUpdateEventConversationVoiceChannelDeactivate:
-            case ZMUpdateEventUserConnection:
-            case ZMUpdateEventUserNew:
-            case ZMUpdateEventUserUpdate:
-            case ZMUpdateEventUserPushRemove:
-            case ZMUpdateEventUserContactJoin:
-            case ZMUpdateEventUserClientAdd:
-            case ZMUpdateEventUserClientRemove:
-            case ZMUpdateEventTeamCreate:
-            case ZMUpdateEventTeamDelete:
-            case ZMUpdateEventTeamUpdate:
-            case ZMUpdateEventTeamMemberJoin:
-            case ZMUpdateEventTeamMemberLeave:
-            case ZMUpdateEventTeamMemberUpdate:
-            case ZMUpdateEventTeamConversationCreate:
-            case ZMUpdateEventTeamConversationDelete:
-            case ZMUpdateEvent_LAST:
-                break;
-        }
-        __block NSString *typeString;
-        [self.typesMapping enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSNumber *encodedType, BOOL *stop) {
-            if (encodedType.intValue == (int) type) {
-                *stop = YES;
-                typeString = name;
-            }
-        }];
-        XCTAssertNotNil(typeString, @"%d", (int) type);
-        
-        // when
-        ZMUpdateEvent *sut = [ZMUpdateEvent eventFromEventStreamPayload:@{@"type": typeString} uuid:nil];
-        
-        // then
-        XCTAssertEqual(sut.isFlowEvent, expected, @"%d", (int) type);
-    }
 }
 
 @end


### PR DESCRIPTION
These events all belong to the V2 calling protocol which is no longer in use.