### PR TITLE
ZIOS-9202: Added Websocket Nonce generator

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "wireapp/ocmock" "v3.4"
 github "wireapp/wire-ios-system" "19.0.1"
 github "wireapp/wire-ios-testing" "13.0.1"
-github "wireapp/wire-ios-utilities" "18.0.1"
+github "wireapp/wire-ios-utilities" "18.1.1"

--- a/Source/PushChannel/ZMWebSocket.m
+++ b/Source/PushChannel/ZMWebSocket.m
@@ -116,7 +116,7 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_PUSHCHANNEL;
     NSMutableDictionary *headers = [@{@"Upgrade": @"websocket",
                               @"Host": self.URL.host,
                               @"Connection": @"Upgrade",
-                              @"Sec-WebSocket-Key": @"dGhlIHNhbXBsZSBub25jZQ==",
+                              @"Sec-WebSocket-Key": [self generateWebSocketNonce],
                               @"Sec-WebSocket-Version": @"13"} mutableCopy];
     [headers addEntriesFromDictionary:self.additionalHeaderFields];
     [headers enumerateKeysAndObjectsUsingBlock:^(NSString *headerField, NSString *headerValue, BOOL * ZM_UNUSED stop){
@@ -238,6 +238,18 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_PUSHCHANNEL;
 - (void)didReceivePong;
 {
     ZMLogDebug(@"Received PONG");
+}
+
+-(NSString*)generateWebSocketNonce
+{
+    NSUInteger dataLength = 16;
+    NSMutableData* data = [NSMutableData dataWithCapacity:dataLength];
+    for(unsigned int i = 0; i < dataLength / 4; i++) {
+        u_int32_t randomBits = arc4random();
+        [data appendBytes:(void*)&randomBits length:4];
+    }
+    NSString *base64String = [data base64EncodedStringWithOptions:0];
+    return base64String;
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

A hardcoded value was found for the WebSocket request header Sec-WebSocket-Key.
This value is a dummy value specified in RFC6455 4 . This RFC also makes it mandatory to always use a random base64 encoded nonce for the header value:

> The request MUST include a header field with the name |Sec-WebSocket-Key|. The value of this header field MUST be a nonce consisting of a randomly selected 16-byte value that has been base64-encoded (see Section 4 of [RFC4648]). The nonce MUST be selected randomly for each connection.

### Solutions

A random nonce is generated for each connection and request as specified by RFC6544, by using the new `generateWebSocketNonce` method.
