### PR TITLE
Potential fix for the stream crash

### DIFF
--- a/Source/PushChannel/NetworkSocket.swift
+++ b/Source/PushChannel/NetworkSocket.swift
@@ -81,6 +81,16 @@ import Foundation
     }
     
     deinit {
+        if let inputStream = self.inputStream {
+            inputStream.delegate = nil
+            inputStream.close()
+        }
+        
+        if let outputStream = self.outputStream {
+            outputStream.delegate = nil
+            outputStream.close()
+        }
+        
         assert(self.state == .stopped)
     }
     

--- a/Source/PushChannel/NetworkSocket.swift
+++ b/Source/PushChannel/NetworkSocket.swift
@@ -91,7 +91,7 @@ import Foundation
             outputStream.close()
         }
         
-        assert(self.state == .stopped)
+        requireInternal(self.state == .stopped, "Socket is still running")
     }
     
     public func open() {


### PR DESCRIPTION
We see in the Hockey that internal users who are using the new socket implementation are experiencing one in a while a crash when the input stream cannot send the callback to it's delegate. My idea is that the assert is not firing, since it's only crashing on the development, and the delegate reference is not nullified after the `NetworkSocket` is deallocated.

Potential solution is to additionally nullify the delegates in dealloc.