### PR TITLE
Renamed enqeueSearchRequest to enqueueOneRequest

### DIFF
--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -92,7 +92,7 @@ extern NSString * const ZMTransportSessionNewRequestAvailableNotification;
 /// Sets the access token success callback
 - (void)setAccessTokenRenewalSuccessHandler:(ZMAccessTokenHandlerBlock)handler;
 
-- (void)enqueueSearchRequest:(ZMTransportRequest *)searchRequest;
+- (void)enqueueOneTimeRequest:(ZMTransportRequest *)searchRequest;
 - (ZMTransportEnqueueResult *)attemptToEnqueueSyncRequestWithGenerator:(ZMTransportRequestGenerator)requestGenerator;
 
 - (void)setNetworkStateDelegate:(nullable id<ZMNetworkStateDelegate>)delegate;

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -350,7 +350,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     [self.urlSessionSwitch.backgroundSession getTasksWithCompletionHandler:completionHandler];
 }
 
-- (void)enqueueSearchRequest:(ZMTransportRequest *)searchRequest;
+- (void)enqueueOneTimeRequest:(ZMTransportRequest *)searchRequest;
 {
     OSAtomicIncrement32Barrier(&_numberOfRequestsInProgress);
     [self enqueueTransportRequest:searchRequest];

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -603,7 +603,7 @@ static XCTestCase *currentTestCase;
     ZMTransportRequest *request =[ZMTransportRequest requestWithPath:@"foo" method:ZMMethodGET payload:nil];
     
     // when
-    [self.sut enqueueSearchRequest:request];
+    [self.sut enqueueOneTimeRequest:request];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // then


### PR DESCRIPTION
- Method implementation is not relevant to search.
- Now it's going to be used to fetch the service metadata or add service to the conversation.