### PR TITLE
Added svg mime type to blacklist of non-image types

### DIFF
--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -457,7 +457,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     {
         for (NSString *uti in CFBridgingRelease(CGImageSourceCopyTypeIdentifiers())) {
             NSString *mime = CFBridgingRelease(UTTypeCopyPreferredTagWithClass((__bridge CFStringRef) uti, kUTTagClassMIMEType));
-            if ((mime == nil) || [mime hasPrefix:@"image/x-"] || [mime hasPrefix:@"application/"]) {
+            if ((mime == nil) || [mime hasPrefix:@"image/x-"] || [mime hasPrefix:@"image/svg+xml"] || [mime hasPrefix:@"application/"]) {
                 continue;
             }
             [types addObject:mime];

--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -456,8 +456,10 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     NSMutableArray *types = [NSMutableArray array];
     {
         for (NSString *uti in CFBridgingRelease(CGImageSourceCopyTypeIdentifiers())) {
-            NSString *mime = CFBridgingRelease(UTTypeCopyPreferredTagWithClass((__bridge CFStringRef) uti, kUTTagClassMIMEType));
-            if ((mime == nil) || [mime hasPrefix:@"image/x-"] || [mime hasPrefix:@"image/svg+xml"] || [mime hasPrefix:@"application/"]) {
+            CFStringRef mimeType = UTTypeCopyPreferredTagWithClass((__bridge CFStringRef) uti, kUTTagClassMIMEType);
+            NSString *mime = CFBridgingRelease(mimeType);
+            if ((mime == nil) || [mime hasPrefix:@"image/x-"] ||
+                UTTypeConformsTo(mimeType, kUTTypeScalableVectorGraphics) || [mime hasPrefix:@"application/"]) {
                 continue;
             }
             [types addObject:mime];


### PR DESCRIPTION
## What's new in this PR?

I've added a filter for the MIME type `image/svg+xml` in `ZMTransportRequest.m`, since it cannot be considered as an image type from our side (see "Dependencies").

## Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/wire-ios-message-strategy/pull/108
- [ ] https://github.com/wireapp/wire-ios-data-model/pull/424