### PR TITLE
Clean up unauthenticated network logs

### DIFF
--- a/Source/TransportSession/UnauthenticatedTransportSession.swift
+++ b/Source/TransportSession/UnauthenticatedTransportSession.swift
@@ -44,13 +44,13 @@ private let zmLog = ZMSLog(tag: "Network")
 
 fileprivate extension ZMTransportRequest {
     func log() -> Void {
-        zmLog.debug("[Unauthenticated] ----> Request: \(ZMTransportRequest.string(for: method))\n\(self)")
+        zmLog.debug("[Unauthenticated] ----> Request: \(description)")
     }
 }
 
 fileprivate extension ZMTransportResponse {
     func log() -> Void {
-        zmLog.debug("[Unauthenticated] <---- Response: \(String(describing: headers))\n\(String(describing: payload))")
+        zmLog.debug("[Unauthenticated] <---- Response: \(description)")
     }
 }
 
@@ -112,7 +112,7 @@ final public class UnauthenticatedTransportSession: NSObject, UnauthenticatedTra
                 preconditionFailure()
             }
             
-            transportResponse.log()
+            transportResponse?.log()
             request.complete(with: transportResponse)
             self?.decrement(notify: true)
         }


### PR DESCRIPTION
## What's new in this PR?

The logs of the unauthenticated transport session were not really readable:

```
Network [Unauthenticated] <---- Response: Optional([AnyHashable("Content-Type"): text/plain; 
charset=UTF-8, AnyHashable("Content-Length"): 20, AnyHashable("Connection"): keep-alive,
AnyHashable("Request-Id"): f33a7c4e4b9f78f7f1c23874b39f0746, AnyHashable("Access-Control-
Expose-Headers"): Request-Id, Location, AnyHashable("Strict-Transport-Security"): max-
age=31536000; preload, AnyHashable("Access-Control-Allow-Credentials"): true, 
AnyHashable("Server"): nginx, AnyHashable("Date"): Thu, 25 Jan 2018 09:48:46 GMT, 
AnyHashable("Content-Encoding"): gzip])
	nil
```

This PR changes this to use the regular `description` of the requests and responses, also used by the regular, authenticated transport session.
