### PR TITLE
Update payload parsing for service users

### DIFF
--- a/Source/TransportEncoding/ZMUpdateEvent.m
+++ b/Source/TransportEncoding/ZMUpdateEvent.m
@@ -141,7 +141,13 @@
 
 + (nullable instancetype)eventFromEventStreamPayload:(id<ZMTransportData>)payload uuid:(NSUUID *)uuid
 {
-    return [[self alloc] initWithUUID:uuid payload:[payload asDictionary] transient:NO decrypted:NO source:ZMUpdateEventSourceDownload];
+    NSDictionary *dictionary = payload.asDictionary;
+
+    // Some payloads are wrapped inside "event" key (e.g. removing bot from conversation)
+    // Check for this before
+    NSDictionary *innerPayload = dictionary[@"event"] ?: dictionary;
+
+    return [[self alloc] initWithUUID:uuid payload:innerPayload transient:NO decrypted:NO source:ZMUpdateEventSourceDownload];
 }
 
 + (nullable instancetype)decryptedUpdateEventFromEventStreamPayload:(nonnull id<ZMTransportData>)payload uuid:(nullable NSUUID *)uuid transient:(BOOL)transient source:(ZMUpdateEventSource)source

--- a/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
+++ b/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
@@ -276,6 +276,29 @@
     XCTAssertEqualObjects(event.payload, payload);
 }
 
+- (void)testThatItSetsPayloadFromStreamEventWithWrappedPayload
+{
+    // given
+    NSDictionary *payload = @{
+        @"conversation" : @"0d30d26f-3b5e-4b7b-8f9a-efa2e5f9ca7c",
+        @"time" : @"2014-06-18T12:36:51.755Z",
+        @"data" : @{
+            @"content" : @"First! ;)",
+            @"nonce" : @"a80a81e3-9ff1-ac27-03ee-06bbc6d7b5cb"
+        },
+        @"from" : @"f76c1c7a-7278-4b70-9df7-eca7980f3a5d",
+        @"id" : @"8.800122000a68ee1d",
+        @"type" : @"conversation.message-add"
+    };
+    NSDictionary *wrappedPayload = @{ @"event" : payload };
+
+    // when
+    ZMUpdateEvent *event = [ZMUpdateEvent eventFromEventStreamPayload:wrappedPayload uuid:nil];
+
+    // then
+    XCTAssertNotNil(event);
+    XCTAssertEqualObjects(event.payload, payload);
+}
 
 - (void)testThatItSetsIDToNilFromStreamEvent
 {


### PR DESCRIPTION
## What's new in this PR?

### Issues

When removing a service user from conversation the API returns a result that has slightly different payload than usual. It has all the data wrapped inside another dictionary.

### Solutions

When creating a `ZMUpdateEvent` check if the event payload is wrapped inside `"event"` and then process it.
