### PR TITLE
Added tearDown for Reachability

### DIFF
--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -298,6 +298,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     self.tornDown = YES;
     
     self.reachabilityObserverToken = nil;
+    [self.reachability tearDown];
     [self.transportPushChannel closeAndRemoveConsumer];
     [self.workGroup enter];
     [self.workQueue addOperationWithBlock:^{


### PR DESCRIPTION
## What's new in this PR?

Share Extension was crashing because the `reachability` property of `ZMTransportSession` wasn't torn down, causing a crash while switching between accounts. Now I'm calling the `tearDown()` method of `ZMReachability` inside the `tearDown()` of the main class.

## Dependencies

Needs releases with:

- [ ] https://github.com/wireapp/wire-ios/pull/1701
- [ ] https://github.com/wireapp/wire-ios-share-engine/pull/52