### PR TITLE
Push channel opening and closing loop when offline

### DIFF
--- a/Source/PushChannel/ZMTransportPushChannel.m
+++ b/Source/PushChannel/ZMTransportPushChannel.m
@@ -147,7 +147,7 @@ ZM_EMPTY_ASSERTING_INIT();
 
 - (BOOL)shouldBeOpen
 {
-    return !(self.clientID == nil || self.accessToken == nil || self.consumer == nil || !self.keepOpen);
+    return self.clientID != nil && self.accessToken != nil && self.consumer != nil && self.keepOpen && self.scheduler.reachability.mayBeReachable;
 }
 
 - (void)establishConnection


### PR DESCRIPTION
## What's new in this PR?

### Issues

When the app is in foreground and becomes offline (e.g. turning on airplane mode) the push channel is closed but will immediately try to be opened again. Since we are offline this is not possible and it is closed again. This causes a loop until the app goes in the background or we come back offline.

### Solutions

Check reachability when re-opening push channel and do nothing if internet is not reachable. We then later get callback when reachability changes and can open push channel.

