### PR TITLE
ZIOS-9531: Fix crash in NetworkSocket: trying to dealloc socket from background thread

### DIFF
--- a/Source/PushChannel/ZMTransportPushChannel.m
+++ b/Source/PushChannel/ZMTransportPushChannel.m
@@ -97,6 +97,8 @@ ZM_EMPTY_ASSERTING_INIT();
 }
 
 - (void)dealloc {
+    [self.pushChannel close];
+    self.pushChannel = nil;
     [self.scheduler tearDown];
 }
 

--- a/Source/PushChannel/ZMWebSocket.m
+++ b/Source/PushChannel/ZMWebSocket.m
@@ -190,9 +190,13 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_PUSHCHANNEL;
         ZMSDispatchGroup *group = self.consumerGroup;
         self.consumerQueue = nil;
         self.consumerGroup = nil;
-        [group asyncOnQueue:self.networkSocketQueue block:^{
+        
+        // `networkSocketQueue` is specially created to handle all the actions on the `networkSocket`.
+        // therefore it should be safe to dispatch sync on it: it must not be blocked with other
+        // activity.
+        dispatch_sync(self.networkSocketQueue, ^{
             [self.networkSocket close];
-        }];
+        });
         NSHTTPURLResponse *response = self.response;
         self.response = nil;
         id<ZMWebSocketConsumer> consumer = self.consumer;

--- a/Tests/Source/PushChannel/ZMWebSocketTests.m
+++ b/Tests/Source/PushChannel/ZMWebSocketTests.m
@@ -83,7 +83,7 @@
                                                    queue:self.queue
                                                    group:self.fakeUIContext.dispatchGroup
                                            networkSocket:self.networkSocketMock
-                                      networkSocketQueue:self.queue
+                                      networkSocketQueue:nil
                                                      url:self.URL
                                   additionalHeaderFields:nil];
     self.receivedData = [NSMutableArray array];
@@ -242,7 +242,7 @@
                                                    queue:self.queue
                                                    group:self.fakeUIContext.dispatchGroup
                                            networkSocket:self.networkSocketMock
-                                      networkSocketQueue:self.queue
+                                      networkSocketQueue:nil
                                                      url:self.URL
                                   additionalHeaderFields:extraHeaders];
     __block NSData *sentData;


### PR DESCRIPTION
## What's new in this PR?

### Issues

The app is crashing sometimes when coming back from background.

### Causes

This could be caused by the `NetworkSocket` object closed asynchronously in the `close()` method of `ZMWebSocket`.

### Solutions

Now we're closing the `NetworkSocket` synchronously in the proper queue, in order to avoid deadlocks. We're also closing the Push Channel while deallocating `ZMTransportPushChannel`.

## Notes

- Since we don't have steps to reproduce this problem, other fixes could be needed. Let's try to merge so we could eventually collect crash logs.
- Thanks to @mikeger for the support!