### PR TITLE
ZIOS-9531: Moved push channel deallocation to ZMTransportPushChannel

### DIFF
--- a/Source/PushChannel/NetworkSocket.swift
+++ b/Source/PushChannel/NetworkSocket.swift
@@ -84,7 +84,17 @@ import Foundation
     
     deinit {
         if state != .stopped {
-            close(syncDelegate: true)
+            if isOnQueue() {
+                close(syncDelegate: true)
+            }
+            else {
+                // `queue` is specially created to handle all the actions on the `networkSocket`.
+                // therefore it should be safe to dispatch sync on it: it must not be blocked with other
+                // activity.
+                queue.sync {
+                    close(syncDelegate: true)
+                }
+            }
         }
     }
     

--- a/Source/PushChannel/ZMTransportPushChannel.m
+++ b/Source/PushChannel/ZMTransportPushChannel.m
@@ -207,6 +207,10 @@ ZM_EMPTY_ASSERTING_INIT();
             [scheduler processCompletedURLResponse:response URLError:nil];
         }];
     }
+    
+    if (channel == self.pushChannel) {
+        self.pushChannel = nil;
+    }
 }
 
 - (void)pushChannelDidOpen:(ZMPushChannelConnection *)channel withResponse:(NSHTTPURLResponse *)response;

--- a/Source/PushChannel/ZMWebSocket.m
+++ b/Source/PushChannel/ZMWebSocket.m
@@ -190,13 +190,9 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_PUSHCHANNEL;
         ZMSDispatchGroup *group = self.consumerGroup;
         self.consumerQueue = nil;
         self.consumerGroup = nil;
-        
-        // `networkSocketQueue` is specially created to handle all the actions on the `networkSocket`.
-        // therefore it should be safe to dispatch sync on it: it must not be blocked with other
-        // activity.
-        dispatch_sync(self.networkSocketQueue, ^{
+        [group asyncOnQueue:self.networkSocketQueue block:^{
             [self.networkSocket close];
-        });
+        }];
         NSHTTPURLResponse *response = self.response;
         self.response = nil;
         id<ZMWebSocketConsumer> consumer = self.consumer;


### PR DESCRIPTION
## What's new in this PR?

PR related to network socket crash (ZIOS-9531). We're now deallocating the push channel in the `pushChannelDidClose:withResponse:` method of `ZMTransportPushChannel`. In addition, we're checking for the correct queue while closing the `NetworkSocket`.