### PR TITLE
Add .conversationCodeUpdate to ZMUpdateEventType

### DIFF
--- a/Source/Public/ZMUpdateEvent.swift
+++ b/Source/Public/ZMUpdateEvent.swift
@@ -46,6 +46,8 @@ import WireUtilities
     case conversationOtrAssetAdd
     case conversationRename
     case conversationTyping
+    case conversationCodeUpdate
+    case conversationAccessModeUpdate
     case userConnection
     case userNew
     case userUpdate
@@ -61,7 +63,6 @@ import WireUtilities
     case teamConversationCreate
     case teamConversationDelete
     case teamMemberUpdate
-    case conversationAccessModeUpdate
 
     case _LAST  /// ->->->->->!!! Keep this at the end of this enum !!!<-<-<-<-<-
     /// It is used to enumerate values. Hardcoding the values of this enums in tests gets very easily out of sync
@@ -99,6 +100,10 @@ extension ZMUpdateEventType {
             return "conversation.rename"
         case .conversationTyping:
             return "conversation.typing"
+        case .conversationCodeUpdate:
+            return "conversation.code-update"
+        case .conversationAccessModeUpdate:
+            return "conversation.access-update"
         case .userConnection:
             return "user.connection"
         case .userNew:
@@ -129,8 +134,6 @@ extension ZMUpdateEventType {
             return "team.conversation-delete"
         case .teamMemberUpdate:
             return "team.member-update"
-        case .conversationAccessModeUpdate:
-            return "conversation.access-update"
 
         case ._LAST:
             return nil

--- a/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
+++ b/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
@@ -47,6 +47,8 @@
              @"conversation.otr-asset-add" : @(ZMUpdateEventTypeConversationOtrAssetAdd),
              @"conversation.rename" : @(ZMUpdateEventTypeConversationRename),
              @"conversation.typing" : @(ZMUpdateEventTypeConversationTyping),
+             @"conversation.access-update" : @(ZMUpdateEventTypeConversationAccessModeUpdate),
+             @"conversation.code-update" : @(ZMUpdateEventTypeConversationCodeUpdate),
              @"user.connection" : @(ZMUpdateEventTypeUserConnection),
              @"user.new" : @(ZMUpdateEventTypeUserNew),
              @"user.push-remove" : @(ZMUpdateEventTypeUserPushRemove),
@@ -61,8 +63,7 @@
              @"team.member-leave" : @(ZMUpdateEventTypeTeamMemberLeave),
              @"team.member-update" : @(ZMUpdateEventTypeTeamMemberUpdate),
              @"team.conversation-create" : @(ZMUpdateEventTypeTeamConversationCreate),
-             @"team.conversation-delete" : @(ZMUpdateEventTypeTeamConversationDelete),
-             @"conversation.access-update" : @(ZMUpdateEventTypeConversationAccessModeUpdate)
+             @"team.conversation-delete" : @(ZMUpdateEventTypeTeamConversationDelete)
              };
 }
 


### PR DESCRIPTION
### Issues

The `conversation.code-update` events were missing from the event stream.

### Causes

The event type wasn't mapped.

### Solutions

Add `conversation.code-update` to the list of known events.