### PR TITLE
ZIOS-9743: Possible fix for closure of push channel

### DIFF
--- a/Source/PushChannel/ZMTransportPushChannel.m
+++ b/Source/PushChannel/ZMTransportPushChannel.m
@@ -209,10 +209,11 @@ ZM_EMPTY_ASSERTING_INIT();
     }
     
     if (channel == self.pushChannel) {
-        if([channel isOpen]) {
-            [channel close];
+        if([self.pushChannel isOpen]) {
+            [self.pushChannel close];
+        } else {
+            self.pushChannel = nil;
         }
-        self.pushChannel = nil;
     }
 }
 

--- a/Source/PushChannel/ZMTransportPushChannel.m
+++ b/Source/PushChannel/ZMTransportPushChannel.m
@@ -25,6 +25,8 @@
 #import "ZMPushChannelConnection.h"
 #import "ZMTLogging.h"
 
+#include <stdatomic.h>
+
 static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_PUSHCHANNEL;
 
 @interface ZMTransportPushChannel ()
@@ -36,6 +38,7 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_PUSHCHANNEL;
 @property (nonatomic, weak) id<ZMPushChannelConsumer>  consumer;
 @property (nonatomic, weak) id<ZMSGroupQueue> groupQueue;
 @property (nonatomic) ZMPushChannelConnection *pushChannel;
+@property (nonatomic) dispatch_queue_t pushChannelSyncQ;
 @property (nonatomic, readonly) BOOL shouldBeOpen;
 
 @end
@@ -92,13 +95,21 @@ ZM_EMPTY_ASSERTING_INIT();
         self.url = [URL URLByAppendingPathComponent:@"/await"];
         self.userAgentString = userAgentString;
         self.pushChannelClass = pushChannelClass ?: ZMPushChannelConnection.class;
+        self.pushChannelSyncQ = dispatch_queue_create("Set push channel queue", DISPATCH_QUEUE_SERIAL);
     }
     return self;
 }
 
+- (void)updatingPushChannel:(dispatch_block_t)block
+{
+    dispatch_sync(self.pushChannelSyncQ, block);
+}
+
 - (void)dealloc {
     [self.pushChannel close];
-    self.pushChannel = nil;
+    [self updatingPushChannel:^{
+        self.pushChannel = nil;
+    }];
     [self.scheduler tearDown];
 }
 
@@ -155,7 +166,9 @@ ZM_EMPTY_ASSERTING_INIT();
 - (void)establishConnection
 {
     if (!self.pushChannel.isOpen && self.shouldBeOpen) {
-        self.pushChannel = [[self.pushChannelClass alloc] initWithURL:self.url consumer:self queue:self.groupQueue accessToken:self.accessToken clientID:self.clientID userAgentString:self.userAgentString];
+        [self updatingPushChannel:^{
+            self.pushChannel = [[self.pushChannelClass alloc] initWithURL:self.url consumer:self queue:self.groupQueue accessToken:self.accessToken clientID:self.clientID userAgentString:self.userAgentString];
+        }];
         
         ZMLogInfo(@"Opening push channel");
     }
@@ -209,11 +222,9 @@ ZM_EMPTY_ASSERTING_INIT();
     }
     
     if (channel == self.pushChannel) {
-        if([self.pushChannel isOpen]) {
-            [self.pushChannel close];
-        } else {
+        [self updatingPushChannel:^{
             self.pushChannel = nil;
-        }
+        }];
     }
 }
 

--- a/Source/PushChannel/ZMTransportPushChannel.m
+++ b/Source/PushChannel/ZMTransportPushChannel.m
@@ -209,6 +209,9 @@ ZM_EMPTY_ASSERTING_INIT();
     }
     
     if (channel == self.pushChannel) {
+        if([channel isOpen]) {
+            [channel close];
+        }
         self.pushChannel = nil;
     }
 }

--- a/Tests/Source/PushChannel/ZMPushChannelConnectionTests.m
+++ b/Tests/Source/PushChannel/ZMPushChannelConnectionTests.m
@@ -48,7 +48,6 @@
     XCTAssertEqual(channel, self.sut);
     XCTAssertNotNil(data);
     XCTAssertTrue(channel.isOpen);
-//    ZMAssertGroupQueue(self.uiMOC);
     [self.receivedData addObject:data ?: @{}];
 }
 
@@ -57,7 +56,6 @@
     NOT_USED(response);
     XCTAssertTrue((self.sut == nil) || (channel == self.sut));
     XCTAssertFalse(channel.isOpen);
-    //    ZMAssertGroupQueue(self.uiMOC);
     self.closeCounter++;
 }
 
@@ -66,7 +64,6 @@
     NOT_USED(response);
     XCTAssertEqual(channel, self.sut);
     XCTAssertTrue(channel.isOpen);
-//    ZMAssertGroupQueue(self.uiMOC);
     self.openCounter++;
 }
 

--- a/Tests/Source/PushChannel/ZMPushChannelConnectionTests.m
+++ b/Tests/Source/PushChannel/ZMPushChannelConnectionTests.m
@@ -47,6 +47,7 @@
 {
     XCTAssertEqual(channel, self.sut);
     XCTAssertNotNil(data);
+    XCTAssertTrue(channel.isOpen);
 //    ZMAssertGroupQueue(self.uiMOC);
     [self.receivedData addObject:data ?: @{}];
 }
@@ -55,7 +56,8 @@
 {
     NOT_USED(response);
     XCTAssertTrue((self.sut == nil) || (channel == self.sut));
-//    ZMAssertGroupQueue(self.uiMOC);
+    XCTAssertFalse(channel.isOpen);
+    //    ZMAssertGroupQueue(self.uiMOC);
     self.closeCounter++;
 }
 
@@ -63,6 +65,7 @@
 {
     NOT_USED(response);
     XCTAssertEqual(channel, self.sut);
+    XCTAssertTrue(channel.isOpen);
 //    ZMAssertGroupQueue(self.uiMOC);
     self.openCounter++;
 }


### PR DESCRIPTION
## What's new in this PR?

A possible fix for the new crash related to push channel closure. The behavior is similar to the previous crash. This time, the `pushChannelDidClose:withResponse:` method is called but, when we set `self.pushChannel = nil`, the channel seems to be still open. At that point, I'm trying to close the channel again. Theoretically, at the next iteration, the push channel should be closed.

## Notes

@mikeger do you have any suggestions?