### PR TITLE
Attempt to fix crash in push channel

### DIFF
--- a/Source/PushChannel/ZMTransportPushChannel.h
+++ b/Source/PushChannel/ZMTransportPushChannel.h
@@ -39,12 +39,15 @@
 
 - (void)setPushChannelConsumer:(id<ZMPushChannelConsumer>)consumer groupQueue:(id<ZMSGroupQueue>)groupQueue;
 - (void)closeAndRemoveConsumer;
+
+/// Open push channel connection.
+///
+/// NOTE: Must be called from transport session queue.
 - (void)establishConnection;
 
-/// Will open the push channel if all required conditions are met
-- (void)attemptToOpen;
-
-/// Will close the push channel until @c attemptToOpen is called
-- (void)close;
+/// Will open the push channel if all required conditions are met.
+///
+/// NOTE: Must be called from transport session queue.
+- (void)attemptToOpenPushChannelConnection;
 
 @end

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -676,7 +676,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 - (void)schedulerIncreasedMaximumNumberOfConcurrentRequests:(ZMTransportRequestScheduler *)scheduler;
 {
     ZMLogDebug(@"%@ Notify new request" , NSStringFromSelector(_cmd));
-    [self.transportPushChannel attemptToOpen];
+    [self.transportPushChannel attemptToOpenPushChannelConnection];
     [ZMTransportSession notifyNewRequestsAvailable:scheduler];
 }
 

--- a/Tests/Source/Fakes.h
+++ b/Tests/Source/Fakes.h
@@ -19,11 +19,9 @@
 
 @import WireTransport;
 
-//////////////////////////////////////////////////
-//
 #pragma mark - FakeURLResponse
-//
-//////////////////////////////////////////////////
+
+
 @class FakeURLResponse;
 @interface FakeDataTask : NSObject
 
@@ -40,11 +38,8 @@
 @end
 
 
-//////////////////////////////////////////////////
-//
 #pragma mark - FakeURLResponse
-//
-//////////////////////////////////////////////////
+
 
 @interface FakeURLResponse : NSObject
 
@@ -59,14 +54,8 @@
 @end
 
 
-
-
-
-//////////////////////////////////////////////////
-//
 #pragma mark - FakeTransportResponse
-//
-//////////////////////////////////////////////////
+
 
 @interface FakeTransportResponse : NSObject
 + (instancetype)testResponse;
@@ -76,13 +65,8 @@
 @end
 
 
-
-
-//////////////////////////////////////////////////
-//
 #pragma mark - FakeExponentialBackoff
-//
-//////////////////////////////////////////////////
+
 
 @interface FakeExponentialBackoff : NSObject
 @property (nonatomic) NSMutableArray *blocks;
@@ -91,18 +75,18 @@
 @end
 
 
-
-
-//////////////////////////////////////////////////
-//
 #pragma mark - FakeDelegate
-//
-//////////////////////////////////////////////////
 
 
 @interface FakeDelegate : NSObject <ZMAccessTokenHandlerDelegate>
 @property (nonatomic) NSUInteger delegateCallCount;
 @property (nonatomic, copy) dispatch_block_t didReceiveAccessTokenBlock;
+@end
+
+#pragma mark - ZMSGroupQueue
+
+@interface FakeGroupQueue : NSObject <ZMSGroupQueue>
+
 @end
 
 

--- a/Tests/Source/Fakes.m
+++ b/Tests/Source/Fakes.m
@@ -20,7 +20,6 @@
 #import "Fakes.h"
 
 
-
 @implementation FakeDataTask
 
 - (instancetype)initWithError:(NSError *)error taskIdentifier:(NSUInteger)taskIdentifier response:(FakeURLResponse *)response
@@ -59,9 +58,6 @@
 }
 
 @end
-
-
-
 
 
 @implementation FakeURLResponse
@@ -122,8 +118,6 @@
 @end
 
 
-
-
 @implementation FakeExponentialBackoff
 
 - (instancetype)init;
@@ -157,9 +151,6 @@
 @end
 
 
-
-
-
 @implementation FakeDelegate
 
 - (void)handlerDidReceiveAccessToken:(id)sender
@@ -175,6 +166,21 @@
 - (void)handlerDidClearAccessToken:(ZMAccessTokenHandler * __unused)handler
 {
     // TODO
+}
+
+@end
+
+
+@implementation FakeGroupQueue
+
+- (void)performGroupedBlock:(dispatch_block_t)block
+{
+    block();
+}
+
+- (ZMSDispatchGroup *)dispatchGroup
+{
+    return nil;
 }
 
 @end

--- a/Tests/Source/PushChannel/ZMTransportPushChannelTests.m
+++ b/Tests/Source/PushChannel/ZMTransportPushChannelTests.m
@@ -26,6 +26,7 @@
 #import "ZMPushChannelConnection.h"
 #import "ZMTransportSession+internal.h"
 #import "ZMAccessToken.h"
+#import "Fakes.h"
 #import "WireTransport_ios_tests-Swift.h"
 
 
@@ -67,6 +68,7 @@ static FakePushChannelConnection *currentFakePushChannelConnection;
 @property (nonatomic) id consumer;
 @property (nonatomic) ZMTransportPushChannel<ZMPushChannelConsumer> *sut;
 @property (nonatomic) FakeReachability* reachability;
+@property (nonatomic) FakeGroupQueue *fakeGroup;
 
 @end
 
@@ -84,9 +86,10 @@ static FakePushChannelConnection *currentFakePushChannelConnection;
     self.pushChannelURL = [NSURL URLWithString:@"https://pushchannel.example.com/foo"];
     self.reachability = [[FakeReachability alloc] init];
     self.reachability.mayBeReachable = YES;
+    self.fakeGroup = [[FakeGroupQueue alloc] init];
 
     self.scheduler = [OCMockObject niceMockForClass:ZMTransportRequestScheduler.class];
-    [[self.scheduler expect] tearDown];
+//    [[self.scheduler expect] tearDown];
     [[[self.scheduler stub] andCall:@selector(schedulerPerformGroupedBlock:) onObject:self] performGroupedBlock:OCMOCK_ANY];
     [self verifyMockLater:self.scheduler];
     self.sut = (id) [[ZMTransportPushChannel alloc] initWithScheduler:self.scheduler userAgentString:self.userAgentString URL:self.pushChannelURL pushChannelClass:FakePushChannelConnection.class];
@@ -99,6 +102,7 @@ static FakePushChannelConnection *currentFakePushChannelConnection;
     currentFakePushChannelConnection = nil;
     self.sut = nil;
     self.scheduler = nil;
+    self.fakeGroup = nil;
     [super tearDown];
 }
 
@@ -112,7 +116,7 @@ static FakePushChannelConnection *currentFakePushChannelConnection;
     if (self.consumer == nil) {
         self.consumer = [OCMockObject niceMockForProtocol:@protocol(ZMPushChannelConsumer)];
     }
-    [self.sut setPushChannelConsumer:self.consumer groupQueue:self.fakeUIContext];
+    [self.sut setPushChannelConsumer:self.consumer groupQueue:self.fakeGroup];
 }
 
 - (void)setupConsumerAndStubbedScheduler;
@@ -179,8 +183,6 @@ static FakePushChannelConnection *currentFakePushChannelConnection;
     XCTAssertEqualObjects(currentFakePushChannelConnection.accessToken, self.accessToken);
     XCTAssertEqualObjects(currentFakePushChannelConnection.clientID, self.clientID);
     XCTAssertEqual(currentFakePushChannelConnection.consumer, self.sut);
-    id<ZMSGroupQueue> queue = currentFakePushChannelConnection.queue;
-    XCTAssertEqual(queue, self.fakeUIContext);
 }
 
 - (void)testThatItDoesNotOpenThePushChannelWhenItDoesNotHaveAConsumer;
@@ -233,7 +235,7 @@ static FakePushChannelConnection *currentFakePushChannelConnection;
     [self openPushChannel];
     
     // when
-    [self.sut close];
+    [currentFakePushChannelConnection close];
     
     // then
     XCTAssertEqual(currentFakePushChannelConnection.closeCounter, 1u);
@@ -246,7 +248,7 @@ static FakePushChannelConnection *currentFakePushChannelConnection;
     id const firstPushChannel = currentFakePushChannelConnection;
     
     // when
-    [self.sut close];
+    [currentFakePushChannelConnection close];
     [self.sut establishConnection];
     id const secondPushChannel = currentFakePushChannelConnection;
     
@@ -505,14 +507,14 @@ static FakePushChannelConnection *currentFakePushChannelConnection;
     // given
     [self setupConsumerAndScheduler];
     [self setupClientIDAndAccessToken];
-    [self.sut close];
+    [currentFakePushChannelConnection close];
     
     // expect
     [(ZMTransportRequestScheduler *)[self.scheduler expect] addItem:openPushChannelItem];
     [(ZMTransportRequestScheduler *)[[self.scheduler expect] andReturn:self.reachability] reachability];
 
     // when
-    [self.sut attemptToOpen];
+    [self.sut attemptToOpenPushChannelConnection];
 }
 
 - (void)testThatItClosesThePushChannelConnectionWhenTheReachabilityChangesFromMobileToWifi

--- a/Tests/Source/PushChannel/ZMTransportPushChannelTests.m
+++ b/Tests/Source/PushChannel/ZMTransportPushChannelTests.m
@@ -89,7 +89,6 @@ static FakePushChannelConnection *currentFakePushChannelConnection;
     self.fakeGroup = [[FakeGroupQueue alloc] init];
 
     self.scheduler = [OCMockObject niceMockForClass:ZMTransportRequestScheduler.class];
-//    [[self.scheduler expect] tearDown];
     [[[self.scheduler stub] andCall:@selector(schedulerPerformGroupedBlock:) onObject:self] performGroupedBlock:OCMOCK_ANY];
     [self verifyMockLater:self.scheduler];
     self.sut = (id) [[ZMTransportPushChannel alloc] initWithScheduler:self.scheduler userAgentString:self.userAgentString URL:self.pushChannelURL pushChannelClass:FakePushChannelConnection.class];

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -288,7 +288,7 @@ static FakePushChannel *currentFakePushChannel;
     self.closeCount++;
 }
 
-- (void)attemptToOpen
+- (void)attemptToOpenPushChannelConnection
 {
     self.scheduleOpenPushChannelCount++;
 }
@@ -300,25 +300,6 @@ static FakePushChannel *currentFakePushChannel;
 }
 @end
 
-#pragma mark - ZMSGroupQueue
-
-@interface FakeGroupQueue : NSObject <ZMSGroupQueue>
-
-@end
-
-@implementation FakeGroupQueue
-
-- (void)performGroupedBlock:(dispatch_block_t)block
-{
-    block();
-}
-
-- (ZMSDispatchGroup *)dispatchGroup
-{
-    return nil;
-}
-
-@end
 //////////////////////////////////////////////////
 //
 #pragma mark - Reachability


### PR DESCRIPTION
### Issues

The push channel connection would sometimes assert in dealloc because it wasn't closed. 

### Causes

After inspecting the threads involved I think this is a race condition created by the fact that the push channel methods are executed on both the sync thread and transport session thread. In particular the `establishConnection` method is executed on the transport session queue and the `pushChannelDidClose:withResponse:` is executed on the sync moc queue. If executed simultaneously this can lead to the situation that a push channel created and then immediately being deallocated.

### Solutions

Re-factor the push channel to only operate on the transport session queue.