### PR TITLE
Only set scheduler state to offline when reachability is offline as well

### DIFF
--- a/Source/TransportSession/ZMTransportRequestScheduler.m
+++ b/Source/TransportSession/ZMTransportRequestScheduler.m
@@ -316,7 +316,7 @@ ZM_EMPTY_ASSERTING_INIT();
             ZMLogDebug(@"Scheduler is Normal");
             self.schedulerState = ZMTransportRequestSchedulerStateNormal;
         }
-    } else if (errorCode != 0) {
+    } else if (errorCode != 0 && !self.reachability.mayBeReachable) {
         ZMLogDebug(@"Scheduler is Offline");
         self.schedulerState = ZMTransportRequestSchedulerStateOffline;
     }

--- a/Tests/Source/TransportSession/ZMTransportRequestSchedulerTests.m
+++ b/Tests/Source/TransportSession/ZMTransportRequestSchedulerTests.m
@@ -461,10 +461,24 @@
     self.sut.schedulerState = ZMTransportRequestSchedulerStateNormal;
     
     // when
+    self.reachability.mayBeReachable = NO;
     [self.sut processCompletedURLTask:[self fakeTaskWithHTTPStatusCode:0 URLErrorCode:NSURLErrorCannotFindHost]];
     
     // then
     XCTAssertEqual(self.sut.schedulerState, ZMTransportRequestSchedulerStateOffline);
+}
+
+- (void)testThatItDoesNotChangeTheStateToOfflineWhenARequestFailsButWeAreReachable;
+{
+    // given
+    self.sut.schedulerState = ZMTransportRequestSchedulerStateNormal;
+    
+    // when
+    self.reachability.mayBeReachable = YES;
+    [self.sut processCompletedURLTask:[self fakeTaskWithHTTPStatusCode:0 URLErrorCode:NSURLErrorCannotFindHost]];
+    
+    // then
+    XCTAssertEqual(self.sut.schedulerState, ZMTransportRequestSchedulerStateNormal);
 }
 
 - (void)testThatItDoesNotNotifyTheDelegateWhenARequestFails;


### PR DESCRIPTION
## What's new in this PR?

We used to set the scheduler state to offline when a request fails with an error other than 0, timeout or cancelled.
If at the same time reachability does not think we are actually offline we will only ever set the scheduler state to online again when reachability detects a connection, which won't happen as we are actually still online. A lot of the time the "messages stuck" issue happened when switching networks, I can easily imagine requests failing when switching network but reachability maybe already being back online by that time.

This is a first quick and easy approach to not have this two different sources of truth (a failed request flips the scheduler state to offline independent of the current reachability, but only reachability will flip it back). We now query the current reachability status when a request fails with a reason other than timeout or cancelled and set the scheduler state according to that.