### PR TITLE
Fix push channel getting stuck

### DIFF
--- a/Source/Public/ZMPushChannelConnection.h
+++ b/Source/Public/ZMPushChannelConnection.h
@@ -63,7 +63,7 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ZMPushChannelConsumer <NSObject>
 
 - (void)pushChannel:(ZMPushChannelConnection *)channel didReceiveTransportData:(id<ZMTransportData>)data;
-- (void)pushChannelDidClose:(ZMPushChannelConnection *)channel withResponse:(nullable NSHTTPURLResponse *)response;
+- (void)pushChannelDidClose:(ZMPushChannelConnection *)channel withResponse:(nullable NSHTTPURLResponse *)response error:(nullable NSError *)error;
 - (void)pushChannelDidOpen:(ZMPushChannelConnection *)channel withResponse:(nullable NSHTTPURLResponse *)response;
 
 @end

--- a/Source/Public/ZMTransportRequestScheduler.h
+++ b/Source/Public/ZMTransportRequestScheduler.h
@@ -62,6 +62,7 @@ extern NSInteger const ZMTransportRequestSchedulerRequestCountUnlimited;
 /// The task given access to the NSHTTPURLResponse and NSError.
 - (void)processCompletedURLTask:(NSURLSessionTask *)task;
 - (void)processCompletedURLResponse:(nullable NSHTTPURLResponse *)response URLError:(nullable NSError *)error;
+- (void)processWebSocketError:(NSError *)error;
 
 - (void)sessionDidReceiveAccessToken:(id<ZMTransportRequestSchedulerSession>)session;
 /// The scheduler uses this to retry sending requests if it's in offline mode.

--- a/Source/PushChannel/ZMWebSocket.h
+++ b/Source/PushChannel/ZMWebSocket.h
@@ -23,6 +23,11 @@
 @protocol ZMSGroupQueue;
 @class NetworkSocket;
 
+extern NSString * const ZMWebSocketErrorDomain;
+typedef NS_ENUM(NSInteger, ZMWebSocketErrorCode) {
+    ZMWebSocketErrorCodeInvalid = 0,
+    ZMWebSocketErrorCodeLostConnection
+};
 
 
 @interface ZMWebSocket : NSObject
@@ -57,6 +62,6 @@
 - (void)webSocketDidCompleteHandshake:(ZMWebSocket *)websocket HTTPResponse:(NSHTTPURLResponse *)response;
 - (void)webSocket:(ZMWebSocket *)webSocket didReceiveFrameWithData:(NSData *)data;
 - (void)webSocket:(ZMWebSocket *)webSocket didReceiveFrameWithText:(NSString *)text;
-- (void)webSocketDidClose:(ZMWebSocket *)webSocket HTTPResponse:(NSHTTPURLResponse *)response;
+- (void)webSocketDidClose:(ZMWebSocket *)webSocket HTTPResponse:(NSHTTPURLResponse *)response error:(NSError *)error;
 
 @end

--- a/Tests/Source/PushChannel/ZMLiveWebSocketTests.m
+++ b/Tests/Source/PushChannel/ZMLiveWebSocketTests.m
@@ -82,9 +82,10 @@
     [self.receivedText addObject:text];
 }
 
-- (void)webSocketDidClose:(ZMWebSocket *)webSocket HTTPResponse:(NSHTTPURLResponse *)response;
+- (void)webSocketDidClose:(ZMWebSocket *)webSocket HTTPResponse:(NSHTTPURLResponse *)response error:(NSError *)error;
 {
     NOT_USED(response);
+    NOT_USED(error);
     XCTAssertEqual(webSocket, self.sut);
 //    ZMAssertGroupQueue(self.uiMOC);
     ++self.closeCounter;

--- a/Tests/Source/PushChannel/ZMPushChannelConnectionTests.m
+++ b/Tests/Source/PushChannel/ZMPushChannelConnectionTests.m
@@ -51,9 +51,10 @@
     [self.receivedData addObject:data ?: @{}];
 }
 
-- (void)pushChannelDidClose:(ZMPushChannelConnection *)channel withResponse:(NSHTTPURLResponse *)response;
+- (void)pushChannelDidClose:(ZMPushChannelConnection *)channel withResponse:(NSHTTPURLResponse *)response error:(nullable NSError *)error;
 {
     NOT_USED(response);
+    NOT_USED(error);
     XCTAssertTrue((self.sut == nil) || (channel == self.sut));
     XCTAssertFalse(channel.isOpen);
     self.closeCounter++;
@@ -272,7 +273,7 @@
 - (void)testThatItCallsDidCloseWhenTheWebSocketCloses;
 {
     // when
-    [self.sut webSocketDidClose:self.webSocketMock HTTPResponse:nil];
+    [self.sut webSocketDidClose:self.webSocketMock HTTPResponse:nil error:nil];
     WaitForAllGroupsToBeEmpty(0.01);
     
     // then
@@ -294,7 +295,7 @@
 {
     // expect
     [[[self.webSocketMock stub] andDo:^(NSInvocation *inv ZM_UNUSED) {
-        [self.sut webSocketDidClose:self.webSocketMock HTTPResponse:nil];
+        [self.sut webSocketDidClose:self.webSocketMock HTTPResponse:nil error:nil];
     }] close];
     
     // when

--- a/Tests/Source/PushChannel/ZMWebSocketTests.m
+++ b/Tests/Source/PushChannel/ZMWebSocketTests.m
@@ -36,6 +36,7 @@
 @property (nonatomic) NSInteger openCounter;
 @property (nonatomic) NSHTTPURLResponse *openResponse;
 @property (nonatomic) NSHTTPURLResponse *closeResponse;
+@property (nonatomic) NSError *closeError;
 @property (nonatomic) dispatch_queue_t queue;
 
 @end
@@ -59,11 +60,12 @@
     [self.receivedText addObject:text];
 }
 
-- (void)webSocketDidClose:(ZMWebSocket *)webSocket HTTPResponse:(NSHTTPURLResponse *)response;
+- (void)webSocketDidClose:(ZMWebSocket *)webSocket HTTPResponse:(NSHTTPURLResponse *)response error:(NSError *)error;
 {
     XCTAssertEqual(webSocket, self.sut);
     ++self.closeCounter;
     self.closeResponse = response;
+    self.closeError = error;
 }
 
 - (void)webSocketDidCompleteHandshake:(ZMWebSocket *)webSocket HTTPResponse:(NSHTTPURLResponse *)response
@@ -454,6 +456,7 @@
     
     // then
     XCTAssertEqual(self.closeCounter, 1);
+    XCTAssertEqual(self.closeError.code, ZMWebSocketErrorCodeLostConnection);
 }
 
 - (void)testThatItClosesTheNetworkSocketWhenItItselfCloses

--- a/WireTransport.xcodeproj/xcshareddata/xcschemes/WireTransport.xcscheme
+++ b/WireTransport.xcodeproj/xcshareddata/xcschemes/WireTransport.xcscheme
@@ -53,7 +53,7 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
-      buildConfiguration = "Release"
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"


### PR DESCRIPTION
### Issues

It's been observed in several cases when the app gets stuck in the syncing state that the push channel refuses to open even though there's a working internet connection.

### Causes

The push channel is only attempting to open a connection if the reachability indicate that there's a working internet connection. This is problematic because on many occasions reachability has missed to report that an internet connection is available when transitioning between networks.

### Solutions

Always attempt to open the push channel but also report to the transport scheduler when the push channel fails to be established so that it can throttle the amount of attempts to open it.