### PR TITLE
Using more general TearDownCapable protocol

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "wireapp/ocmock" "v3.4"
 github "wireapp/wire-ios-system" "20.0.0"
 github "wireapp/wire-ios-testing" "14.0.0"
-github "wireapp/wire-ios-utilities" "23.0.0"
+github "wireapp/wire-ios-utilities" "feature/teardown"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "wireapp/ocmock" "v3.4"
 github "wireapp/wire-ios-system" "20.0.0"
 github "wireapp/wire-ios-testing" "14.0.0"
-github "wireapp/wire-ios-utilities" "feature/teardown"
+github "wireapp/wire-ios-utilities" "23.1.0"

--- a/Source/Public/ZMReachability.h
+++ b/Source/Public/ZMReachability.h
@@ -21,6 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 @import WireSystem;
+@import WireUtilities;
 
 @protocol ZMReachabilityObserver;
 @protocol ReachabilityProvider;
@@ -44,14 +45,7 @@ typedef void (^ReachabilityObserverBlock)(id<ReachabilityProvider> provider);
 
 @end
 
-@protocol ReachabilityTearDown
-
-- (void)tearDown;
-
-@end
-
-
-@interface ZMReachability : NSObject <ReachabilityProvider, ReachabilityTearDown>
+@interface ZMReachability : NSObject <ReachabilityProvider, TearDownCapable>
 
 /// Calls to the observer will always happen on the specified @c observerQueue . All work will be added to the @c group
 - (instancetype)initWithServerNames:(NSArray *)names group:(ZMSDispatchGroup *)group;

--- a/Source/Public/ZMTransportRequestScheduler.h
+++ b/Source/Public/ZMTransportRequestScheduler.h
@@ -51,7 +51,7 @@ extern NSInteger const ZMTransportRequestSchedulerRequestCountUnlimited;
 
 
 
-@interface ZMTransportRequestScheduler : NSObject <ZMReachabilityObserver, ZMSGroupQueue>
+@interface ZMTransportRequestScheduler : NSObject <ZMReachabilityObserver, ZMSGroupQueue, TearDownCapable>
 
 - (instancetype)initWithSession:(id<ZMTransportRequestSchedulerSession>)session operationQueue:(NSOperationQueue *)queue group:(ZMSDispatchGroup *)group reachability:(id<ReachabilityProvider>)reachability;
 - (instancetype)initWithSession:(id<ZMTransportRequestSchedulerSession>)session operationQueue:(NSOperationQueue *)queue group:(ZMSDispatchGroup *)group reachability:(id<ReachabilityProvider>)reachability backoff:(nullable ZMExponentialBackoff *)backoff NS_DESIGNATED_INITIALIZER;

--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -37,7 +37,6 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol ZMKeyValueStore;
 @protocol ZMPushChannel;
 @protocol ReachabilityProvider;
-@protocol ReachabilityTearDown;
 @class ZMURLSessionSwitch;
 @class ZMTransportRequest;
 
@@ -75,12 +74,12 @@ extern NSString * const ZMTransportSessionNewRequestAvailableNotification;
 @property (nonatomic, readonly) ZMPersistentCookieStorage *cookieStorage;
 @property (nonatomic, readonly) ZMURLSessionSwitch *urlSessionSwitch;
 @property (nonatomic, copy) void (^requestLoopDetectionCallback)(NSString*);
-@property (nonatomic, readonly) id<ReachabilityProvider,ReachabilityTearDown> reachability;
+@property (nonatomic, readonly) id<ReachabilityProvider, TearDownCapable> reachability;
 
 - (instancetype)initWithBaseURL:(NSURL *)baseURL
                    websocketURL:(NSURL *)websocketURL
                   cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
-                   reachability:(id<ReachabilityProvider,ReachabilityTearDown>)reachability
+                   reachability:(id<ReachabilityProvider, TearDownCapable>)reachability
              initialAccessToken:(nullable ZMAccessToken *)initialAccessToken
      applicationGroupIdentifier:(nullable NSString *)applicationGroupIdentifier;
 

--- a/Source/Public/ZMURLSession.h
+++ b/Source/Public/ZMURLSession.h
@@ -19,6 +19,7 @@
 
 #import <Foundation/Foundation.h>
 #import <WireSystem/WireSystem.h>
+@import WireUtilities;
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -31,7 +32,7 @@ extern NSString * const ZMURLSessionBackgroundIdentifier;
 extern NSString * const ZMURLSessionForegroundIdentifier;
 extern NSString * const ZMURLSessionVoipIdentifier;
 
-@interface ZMURLSession : NSObject
+@interface ZMURLSession : NSObject <TearDownCapable>
 
 @property (nonatomic, readonly) NSString *identifier;
 

--- a/Source/Public/ZMURLSessionSwitch.h
+++ b/Source/Public/ZMURLSessionSwitch.h
@@ -22,11 +22,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @class ZMURLSession;
+@import WireUtilities;
 
 
 
 /// Switch between instances of ZMURLSession. When switching existing tasks in that session are cancelled.
-@interface ZMURLSessionSwitch : NSObject
+@interface ZMURLSessionSwitch : NSObject <TearDownCapable>
 
 /// The currently selected session
 @property (nonatomic, readonly) ZMURLSession *currentSession;

--- a/Source/Requests/ZMExponentialBackoff.h
+++ b/Source/Requests/ZMExponentialBackoff.h
@@ -19,11 +19,11 @@
 
 #import <Foundation/Foundation.h>
 @import WireSystem;
+@import WireUtilities;
 
 
 
-
-@interface ZMExponentialBackoff : NSObject
+@interface ZMExponentialBackoff : NSObject <TearDownCapable>
 
 - (instancetype)initWithGroup:(ZMSDispatchGroup *)group workQueue:(NSOperationQueue *)workQueue;
 

--- a/Source/TransportSession/UnauthenticatedTransportSession.swift
+++ b/Source/TransportSession/UnauthenticatedTransportSession.swift
@@ -21,7 +21,7 @@ public enum EnqueueResult {
     case success, nilRequest, maximumNumberOfRequests
 }
 
-public protocol UnauthenticatedTransportSessionProtocol: class {
+public protocol UnauthenticatedTransportSessionProtocol: TearDownCapable {
 
     func enqueueRequest(withGenerator generator: ZMTransportRequestGenerator) -> EnqueueResult
     func tearDown()

--- a/Source/TransportSession/ZMTransportSession+internal.h
+++ b/Source/TransportSession/ZMTransportSession+internal.h
@@ -36,7 +36,7 @@
 
 - (instancetype)initWithURLSessionSwitch:(ZMURLSessionSwitch *)URLSessionSwitch
                         requestScheduler:(ZMTransportRequestScheduler *)requestScheduler
-                            reachability:(id<ReachabilityProvider,ReachabilityTearDown>)reachability
+                            reachability:(id<ReachabilityProvider, TearDownCapable>)reachability
                                    queue:(NSOperationQueue *)queue
                                    group:(ZMSDispatchGroup *)group
                                  baseURL:(NSURL *)baseURL

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -90,7 +90,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 @property (nonatomic) NSMutableDictionary <NSString *, dispatch_block_t> *completionHandlerBySessionID;
 
 @property (nonatomic) id<RequestRecorder> requestLoopDetection;
-@property (nonatomic, readwrite) id<ReachabilityProvider,ReachabilityTearDown> reachability;
+@property (nonatomic, readwrite) id<ReachabilityProvider, TearDownCapable> reachability;
 @property (nonatomic) id reachabilityObserverToken;
 
 @end
@@ -173,7 +173,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 - (instancetype)initWithBaseURL:(NSURL *)baseURL
                    websocketURL:(NSURL *)websocketURL
                   cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
-                   reachability:(id<ReachabilityProvider,ReachabilityTearDown>)reachability
+                   reachability:(id<ReachabilityProvider, TearDownCapable>)reachability
              initialAccessToken:(ZMAccessToken *)initialAccessToken
      applicationGroupIdentifier:(NSString *)applicationGroupIdentifier
 {
@@ -211,7 +211,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 - (instancetype)initWithURLSessionSwitch:(ZMURLSessionSwitch *)URLSessionSwitch
                         requestScheduler:(ZMTransportRequestScheduler *)requestScheduler
-                            reachability:(id<ReachabilityProvider,ReachabilityTearDown>)reachability
+                            reachability:(id<ReachabilityProvider, TearDownCapable>)reachability
                                    queue:(NSOperationQueue *)queue
                                    group:(ZMSDispatchGroup *)group
                                  baseURL:(NSURL *)baseURL
@@ -234,7 +234,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 - (instancetype)initWithURLSessionSwitch:(ZMURLSessionSwitch *)URLSessionSwitch
                         requestScheduler:(ZMTransportRequestScheduler *)requestScheduler
-                            reachability:(id<ReachabilityProvider,ReachabilityTearDown>)reachability
+                            reachability:(id<ReachabilityProvider, TearDownCapable>)reachability
                                    queue:(NSOperationQueue *)queue
                                    group:(ZMSDispatchGroup *)group
                                  baseURL:(NSURL *)baseURL
@@ -751,7 +751,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
 @implementation ZMTransportSession (ReachabilityObserver)
 
-- (void)reachabilityDidChange:(id<ReachabilityProvider,ReachabilityTearDown>)reachability;
+- (void)reachabilityDidChange:(id<ReachabilityProvider, TearDownCapable>)reachability;
 {
     ZMLogInfo(@"reachabilityDidChange -> mayBeReachable = %@", reachability.mayBeReachable ? @"YES" : @"NO");
     [self.requestScheduler reachabilityDidChange:reachability];

--- a/Source/URLSession/ZMReachability.m
+++ b/Source/URLSession/ZMReachability.m
@@ -30,7 +30,7 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 
 NSString * const ZMReachabilityChangedNotificationName = @"ZMReachabilityChangedNotification";
 
-@interface ZMReachability() <ReachabilityProvider,ReachabilityTearDown>
+@interface ZMReachability() <ReachabilityProvider, TearDownCapable>
 {
     int32_t _tornDown;
 }

--- a/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -50,7 +50,7 @@ private class MockURLSession: SessionProtocol {
 
 }
 
-private class MockReachability: NSObject, ReachabilityProvider, ReachabilityTearDown {
+private class MockReachability: NSObject, ReachabilityProvider, TearDownCapable {
 
     let mayBeReachable = true
     let isMobileConnection = true

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.swift
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.swift
@@ -20,7 +20,7 @@ import Foundation
 import WireTransport
 import WireTesting
 
-@objc public class FakeReachability: NSObject, ReachabilityProvider, ReachabilityTearDown {
+@objc public class FakeReachability: NSObject, ReachabilityProvider, TearDownCapable {
     
     public var observerCount = 0
     public func add(_ observer: ZMReachabilityObserver, queue: OperationQueue?) -> Any {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Transport had it's own protocol for `tearDown`, using the one from WireSystem instead

## Dependencies

Needs releases with:

- [x] https://github.com/wireapp/wire-ios-utilities/pull/46
