### PR TITLE
ZIOS-9978: Exclude user password from the network log

### DIFF
--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -637,7 +637,13 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     [description appendFormat:@" %lu completionHandler(s)", (unsigned long)self.completionHandlers.count];
     
     if (self.payload) {
-        [description appendFormat:@" payload: %@", self.payload];
+        NSDictionary *payload = (NSDictionary*)self.payload;
+        if([payload isKindOfClass:[NSDictionary class]] && [payload objectForKey:@"password"] != nil) {
+            NSMutableDictionary *mutablePayload = payload.mutableCopy;
+            mutablePayload[@"password"] = @"<redacted>";
+            payload = mutablePayload;
+        }
+        [description appendFormat:@" payload: %@", payload];
     }
     if (self.binaryData) {
         [description appendFormat:@" binary data: %llu", (unsigned long long) self.binaryData.length];

--- a/Tests/Source/Authentication/ZMTransportRequestLoggingTests.swift
+++ b/Tests/Source/Authentication/ZMTransportRequestLoggingTests.swift
@@ -1,0 +1,37 @@
+//
+//  ZMTransportRequestLoggingTests.swift
+//  WireTransport-ios
+//
+//  Created by Nicola Giancecchi on 07.05.18.
+//  Copyright © 2018 Wire. All rights reserved.
+//
+
+import XCTest
+import WireTesting
+@testable import WireTransport
+
+
+final class ZMTransportRequestLoggingTests: ZMTBaseTest {
+
+    
+    func testThatItObfuscatesPasswordsInLogs() {
+        
+        //given
+        let password = "secret"
+        
+        let payload: [String:String] = [
+            "username":"test@test.xyz",
+            "password":password
+        ]
+        
+        //when
+        let requestDescription = ZMTransportRequest(path: "/test",
+                                                    method: .methodGET,
+                                                    payload: payload as ZMTransportData).description
+        
+        //then
+        XCTAssertTrue(requestDescription.contains("password = \"<redacted>\""))
+        XCTAssertFalse(requestDescription.contains("password = \"\(password)\""))
+    }
+}
+

--- a/Tests/Source/Authentication/ZMTransportRequestLoggingTests.swift
+++ b/Tests/Source/Authentication/ZMTransportRequestLoggingTests.swift
@@ -1,10 +1,21 @@
 //
-//  ZMTransportRequestLoggingTests.swift
-//  WireTransport-ios
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
 //
-//  Created by Nicola Giancecchi on 07.05.18.
-//  Copyright © 2018 Wire. All rights reserved.
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
 //
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
 
 import XCTest
 import WireTesting

--- a/WireTransport.xcodeproj/project.pbxproj
+++ b/WireTransport.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		54CA15DF1B32F791008D3787 /* WireTransport.h in Headers */ = {isa = PBXBuildFile; fileRef = 54CA15DE1B32F791008D3787 /* WireTransport.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		54CAD7091BB5411F006FF8E9 /* ZMTLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 54CAD7081BB54097006FF8E9 /* ZMTLogging.h */; };
 		54EA3E6D1BEA65B80071592B /* Fakes.m in Sources */ = {isa = PBXBuildFile; fileRef = 54EA3E6C1BEA65B80071592B /* Fakes.m */; };
+		7C5496DE20A0880C001A9D87 /* ZMTransportRequestLoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5496DC20A085FA001A9D87 /* ZMTransportRequestLoggingTests.swift */; };
 		870F5E671FBF24AD004841E3 /* NetworkSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870F5E661FBF24AD004841E3 /* NetworkSocket.swift */; };
 		871667FE1BB2CD1E009C6EEA /* ZMKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 871667FC1BB2CD1E009C6EEA /* ZMKeychain.m */; };
 		871668001BB2CD2A009C6EEA /* ZMKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 871667FF1BB2CD2A009C6EEA /* ZMKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -331,6 +332,7 @@
 		54CAD7081BB54097006FF8E9 /* ZMTLogging.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZMTLogging.h; sourceTree = "<group>"; };
 		54EA3E6B1BEA65B80071592B /* Fakes.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fakes.h; sourceTree = "<group>"; };
 		54EA3E6C1BEA65B80071592B /* Fakes.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Fakes.m; sourceTree = "<group>"; };
+		7C5496DC20A085FA001A9D87 /* ZMTransportRequestLoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMTransportRequestLoggingTests.swift; sourceTree = "<group>"; };
 		870F5E661FBF24AD004841E3 /* NetworkSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSocket.swift; sourceTree = "<group>"; };
 		871667FC1BB2CD1E009C6EEA /* ZMKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMKeychain.m; sourceTree = "<group>"; };
 		871667FF1BB2CD2A009C6EEA /* ZMKeychain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMKeychain.h; sourceTree = "<group>"; };
@@ -535,6 +537,7 @@
 				546E89C11B33015000DD1042 /* ZMAccessTokenTests.m */,
 				546E89C21B33015000DD1042 /* ZMPersistentCookieStorageTests.m */,
 				F9C4317D1CD7ADF300A8542F /* ZMKeychainTests.m */,
+				7C5496DC20A085FA001A9D87 /* ZMTransportRequestLoggingTests.swift */,
 			);
 			path = Authentication;
 			sourceTree = "<group>";
@@ -1114,6 +1117,7 @@
 				546E89E71B33015000DD1042 /* ZMDataBufferTests.m in Sources */,
 				546E89DD1B33015000DD1042 /* ZMAccessTokenHandlerTests.m in Sources */,
 				546E89FD1B33015000DD1042 /* NSObject_ZMTransportEncodingTests.m in Sources */,
+				7C5496DE20A0880C001A9D87 /* ZMTransportRequestLoggingTests.swift in Sources */,
 				F9331C671CB3D47E00139ECC /* ZMUpdateEventTests.m in Sources */,
 				546E89FB1B33015000DD1042 /* ZMTransportResponseTests.m in Sources */,
 				546E89E51B33015000DD1042 /* ZMTemporaryFileListForBackgroundRequestTests.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

When logging into the app, the password of the user was visible inside logs of internal builds.

### Solutions

Every time we ask the `description` for an instance of `ZMTransportRequest`, if the `payload` field contains a key named `password`, the value for that key is replaced with `<redacted>`.