### PR TITLE
Private description for request

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "wireapp/ocmock" "v3.4"
-github "wireapp/wire-ios-system" "20.0.0"
+github "wireapp/wire-ios-system" "20.2.12"
 github "wireapp/wire-ios-testing" "14.0.0"
 github "wireapp/wire-ios-utilities" "23.1.0"

--- a/Source/Public/ZMTransportRequest.swift
+++ b/Source/Public/ZMTransportRequest.swift
@@ -1,0 +1,39 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+
+import Foundation
+import WireUtilities
+
+extension String {
+    static let UUIDMatcher: NSRegularExpression = {
+        let regex = try! NSRegularExpression(pattern: "[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}", options: .caseInsensitive)
+        return regex
+    }()
+    
+    public var removingUUIDs: String {
+        let range = NSMakeRange(0, self.count)
+        return type(of: self).UUIDMatcher.stringByReplacingMatches(in: self, options: [], range: range, withTemplate: "<uuid>")
+    }
+}
+
+extension ZMTransportRequest: PrivateStringConvertible {
+    public var privateDescription: String {
+        return "\(type(of: self)) \(Unmanaged.passUnretained(self).toOpaque()): method=\(ZMTransportRequest.string(for: self.method)) \(self.path.removingUUIDs)"
+    }
+}

--- a/Tests/Source/Requests/ZMTransportRequestTests.m
+++ b/Tests/Source/Requests/ZMTransportRequestTests.m
@@ -990,4 +990,33 @@
 
 }
 
+- (void)testPrivateDescription
+{
+    // given
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil];
+    
+    // when
+    NSString *privateDescription = [request privateDescription];
+    
+    // then
+    XCTAssertTrue([privateDescription rangeOfString:@"HEAD"].location != NSNotFound);
+    XCTAssertTrue([privateDescription rangeOfString:@"foo"].location != NSNotFound);
+}
+
+- (void)testPrivateDescriptionWithUUID
+{
+    // given
+    NSUUID *uuid = [[NSUUID alloc] init];
+    NSString *path = [NSString stringWithFormat:@"do/something/%@/useful", uuid.transportString];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil];
+    
+    // when
+    NSString *privateDescription = [request privateDescription];
+    
+    // then
+    XCTAssertTrue([privateDescription rangeOfString:@"useful"].location != NSNotFound);
+    XCTAssertTrue([privateDescription rangeOfString:@"do/something"].location != NSNotFound);
+    XCTAssertTrue([privateDescription rangeOfString:uuid.transportString].location == NSNotFound);
+}
+
 @end

--- a/WireTransport.xcodeproj/project.pbxproj
+++ b/WireTransport.xcodeproj/project.pbxproj
@@ -116,6 +116,7 @@
 		870F5E671FBF24AD004841E3 /* NetworkSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870F5E661FBF24AD004841E3 /* NetworkSocket.swift */; };
 		871667FE1BB2CD1E009C6EEA /* ZMKeychain.m in Sources */ = {isa = PBXBuildFile; fileRef = 871667FC1BB2CD1E009C6EEA /* ZMKeychain.m */; };
 		871668001BB2CD2A009C6EEA /* ZMKeychain.h in Headers */ = {isa = PBXBuildFile; fileRef = 871667FF1BB2CD2A009C6EEA /* ZMKeychain.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		87B2B79B20BC476E00799AB9 /* ZMTransportRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87B2B79A20BC476E00799AB9 /* ZMTransportRequest.swift */; };
 		AF9D8F9E1F20D9B700ABF225 /* TestTrustVerificator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9D8F9C1F20D99500ABF225 /* TestTrustVerificator.swift */; };
 		BF3A7A641D8AD5430034FF40 /* SwiftStructs+TransportEncoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF3A7A631D8AD5430034FF40 /* SwiftStructs+TransportEncoding.swift */; };
 		BF3A7A6B1D8C01D30034FF40 /* CoreImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BF3A7A6A1D8C01D30034FF40 /* CoreImage.framework */; };
@@ -336,6 +337,7 @@
 		870F5E661FBF24AD004841E3 /* NetworkSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSocket.swift; sourceTree = "<group>"; };
 		871667FC1BB2CD1E009C6EEA /* ZMKeychain.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMKeychain.m; sourceTree = "<group>"; };
 		871667FF1BB2CD2A009C6EEA /* ZMKeychain.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMKeychain.h; sourceTree = "<group>"; };
+		87B2B79A20BC476E00799AB9 /* ZMTransportRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMTransportRequest.swift; sourceTree = "<group>"; };
 		AF9D8F9C1F20D99500ABF225 /* TestTrustVerificator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestTrustVerificator.swift; sourceTree = "<group>"; };
 		BF3A7A631D8AD5430034FF40 /* SwiftStructs+TransportEncoding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwiftStructs+TransportEncoding.swift"; sourceTree = "<group>"; };
 		BF3A7A6A1D8C01D30034FF40 /* CoreImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreImage.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.0.sdk/System/Library/Frameworks/CoreImage.framework; sourceTree = DEVELOPER_DIR; };
@@ -723,6 +725,7 @@
 				54CA15171B32F2C1008D3787 /* ZMTransportData.h */,
 				54CA15181B32F2C1008D3787 /* ZMTransportRequest.h */,
 				BFC6403B1D2CFE3300886274 /* ZMTransportRequest+AssetGet.h */,
+				87B2B79A20BC476E00799AB9 /* ZMTransportRequest.swift */,
 				54CA15191B32F2C1008D3787 /* ZMTransportRequestScheduler.h */,
 				54CA151A1B32F2C1008D3787 /* ZMTransportResponse.h */,
 				54CA151B1B32F2C1008D3787 /* ZMTransportSession.h */,
@@ -1065,6 +1068,7 @@
 				54CA15C31B32F2C1008D3787 /* ZMTransportData.m in Sources */,
 				54CA15D31B32F2C1008D3787 /* ZMServerTrust.m in Sources */,
 				54CA15C51B32F2C1008D3787 /* NSError+ZMTransportSession.m in Sources */,
+				87B2B79B20BC476E00799AB9 /* ZMTransportRequest.swift in Sources */,
 				54CA15C11B32F2C1008D3787 /* ZMTransportCodec.m in Sources */,
 				54CA15B71B32F2C1008D3787 /* ZMTransportRequest.m in Sources */,
 				54CA15C71B32F2C1008D3787 /* ZMTransportRequestScheduler.m in Sources */,


### PR DESCRIPTION
Comply ZMTransportRequest to PrivateStringConvertible, removing the UUIDs from the request path. This code would be used in the upstream projects (sync engine, ...).