### PR TITLE
Add update event case for conversation.message-timer-update

### DIFF
--- a/Source/Public/ZMUpdateEvent.swift
+++ b/Source/Public/ZMUpdateEvent.swift
@@ -48,6 +48,7 @@ import WireUtilities
     case conversationTyping
     case conversationCodeUpdate
     case conversationAccessModeUpdate
+    case conversationMessageTimerUpdate
     case userConnection
     case userNew
     case userUpdate
@@ -104,6 +105,8 @@ extension ZMUpdateEventType {
             return "conversation.code-update"
         case .conversationAccessModeUpdate:
             return "conversation.access-update"
+        case .conversationMessageTimerUpdate:
+            return "conversation.message-timer-update"
         case .userConnection:
             return "user.connection"
         case .userNew:

--- a/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
+++ b/Tests/Source/TransportEncoding/ZMUpdateEventTests.m
@@ -49,6 +49,7 @@
              @"conversation.typing" : @(ZMUpdateEventTypeConversationTyping),
              @"conversation.access-update" : @(ZMUpdateEventTypeConversationAccessModeUpdate),
              @"conversation.code-update" : @(ZMUpdateEventTypeConversationCodeUpdate),
+             @"conversation.message-timer-update" : @(ZMUpdateEventTypeConversationMessageTimerUpdate),
              @"user.connection" : @(ZMUpdateEventTypeUserConnection),
              @"user.new" : @(ZMUpdateEventTypeUserNew),
              @"user.push-remove" : @(ZMUpdateEventTypeUserPushRemove),


### PR DESCRIPTION
## What's new in this PR?

* Add update event case for `"conversation.message-timer-update"`.