### PR TITLE
Fix wrong tornDown flag being checked on dealloc

### DIFF
--- a/Source/URLSession/ZMReachability.m
+++ b/Source/URLSession/ZMReachability.m
@@ -31,9 +31,6 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 NSString * const ZMReachabilityChangedNotificationName = @"ZMReachabilityChangedNotification";
 
 @interface ZMReachability() <ReachabilityProvider, TearDownCapable>
-{
-    int32_t _tornDown;
-}
 
 @property (nonatomic, copy) NSArray *names;
 @property (nonatomic, copy) NSArray *reachabilityReferences;
@@ -88,7 +85,7 @@ NSString * const ZMReachabilityChangedNotificationName = @"ZMReachabilityChanged
 
 - (void)dealloc;
 {
-    RequireString(_tornDown != 0, "Object was never torn down.");
+    RequireString(self.tornDownFlag.rawValue != 0, "Object was never torn down.");
 }
 
 - (id)addReachabilityObserver:(id<ZMReachabilityObserver>)observer queue:(NSOperationQueue *)queue


### PR DESCRIPTION
## What's new in this PR?

### Issues

`ZMReachability` assert and crash the upon switching accounts.

### Causes

left old `_tornDown` flag was asserted instead of new `tornDownFlag`

### Solutions

Remove `_tornDown ` and assert on `tornDownFlag`