### PR TITLE
Made BackendEnvironment loadable from json

### DIFF
--- a/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -74,8 +74,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
     override func setUp() {
         super.setUp()
         sessionMock = MockURLSession()
-        let customBackend = CustomBackend(backendURL: url, backendWSURL: url, blackListURL: url, frontendURL: url)
-        let environment = BackendEnvironment(customBackend: customBackend)
+        let environment = BackendEnvironment(backendURL: url, backendWSURL: url, blackListURL: url, frontendURL: url)
         sut = UnauthenticatedTransportSession(environment: environment,
                                               urlSession: sessionMock,
                                               reachability: MockReachability())


### PR DESCRIPTION
## What's new in this PR?

### Issues

We had a simple way to use custom backend endpoints, this PR tries to make it easier to customize without making changes in codebase.

### Solutions

`BackendEnvironment` is now `Decodable` and can be loaded from a JSON file. The initializer takes a Bundle that should contain a JSON file for each type of `WireEnvironmentType`. At the moment it's `production.json` and `staging.json`.
