### PR TITLE
Allow string-only payload

### DIFF
--- a/Source/TransportEncoding/ZMTransportCodec.m
+++ b/Source/TransportEncoding/ZMTransportCodec.m
@@ -48,6 +48,10 @@
     if (!object) {
         return [NSData data];
     }
+    if ([object isKindOfClass:[NSString class]]) {
+        NSString *string = (NSString *)object;
+        return [string dataUsingEncoding:NSUTF8StringEncoding];
+    }
     NSError *error;
     return [NSJSONSerialization dataWithJSONObject:object options:0 error:&error];
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

We conform NSString to transport data protocol, but never actually implemented the sending of it.