### PR TITLE
Fix deadlock when running SE tests

### DIFF
--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -171,7 +171,7 @@ private let zmLog = ZMSLog(tag: "background-activity")
     private func handleExpiration() {
         zmLog.debug("Handle expiration")
         let activities = isolationQueue.sync {
-            return activities
+            return self.activities
         }
         activities.forEach { activity in
             zmLog.debug("Handle expiration: notifying \(activity)")


### PR DESCRIPTION
## What's new in this PR?

### Issues

Due to threading issues the tests in Sync Engine would deadlock.

### Causes

We were waiting for DispatchGroup that was waiting for things to happen on main queue.

### Solutions

`handleExpiration()` is called on main queue, so we don't need to first dispatch to internal queue, only accessing the variable needs to be guarded.
