### PR TITLE
Improve background activities logging

### DIFF
--- a/Source/Background/BackgroundActivity.swift
+++ b/Source/Background/BackgroundActivity.swift
@@ -22,6 +22,9 @@ import UIKit
  * A token that represents an active background task.
  */
 
+fileprivate var activityCounter = 0 
+fileprivate let activityCounterQueue = DispatchQueue(label: "wire-transport.background-activity-counter")
+
 @objc public class BackgroundActivity: NSObject {
 
     /// The name of the task, used for debugging purposes.
@@ -33,6 +36,10 @@ import UIKit
     init(name: String, expirationHandler: (() -> Void)?) {
         self.name = name
         self.expirationHandler = expirationHandler
+        // Increment counter with overflow (used in .description)
+        activityCounterQueue.sync {
+            activityCounter &+= 1
+        }
     }
 
     // MARK: - Execution
@@ -76,5 +83,9 @@ import UIKit
 
         return ObjectIdentifier(self) == ObjectIdentifier(otherActivity)
     }
-
+    
+    override public var description: String {
+        let counter = activityCounterQueue.sync { return activityCounter }
+        return "<BackgroundActivity: \(name) [\(counter)]>"
+    }
 }

--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -118,9 +118,13 @@ private let zmLog = ZMSLog(tag: "background-activity")
                 zmLog.debug("End background activity: current background task is invalid")
                 return
             }
+            guard let activityManager = activityManager else {
+                zmLog.debug("End activity [\(activity)]: failed, activityManager is nil")
+                return
+            }
 
             if activities.remove(activity) != nil {
-                zmLog.debug("End background activity: removed \(activity), \(activities.count) others left")
+                zmLog.debug("End background activity: removed \(activity), \(activities.count) others left. App state: \(activityManager.applicationState), time remaining: \(String(format: "%.2f", activityManager.backgroundTimeRemaining))")
             } else {
                 zmLog.debug("End background activity: could not remove \(activity), \(activities.count) others left")
             }
@@ -153,8 +157,8 @@ private let zmLog = ZMSLog(tag: "background-activity")
             let activity = BackgroundActivity(name: name, expirationHandler: expirationHandler)
 
             if currentBackgroundTask == nil {
-                zmLog.debug("Start activity: no current background task, starting new")
-                let task = activityManager.beginBackgroundTask(withName: "BackgroundActivityFactory", expirationHandler: handleExpiration)
+                zmLog.debug("Start activity [\(name)]: no current background task, starting new")
+                let task = activityManager.beginBackgroundTask(withName: name, expirationHandler: handleExpiration)
                 guard task != UIBackgroundTaskInvalid else {
                     zmLog.debug("Start activity [\(name)]: failed to begin new background task")
                     return nil         

--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -124,7 +124,7 @@ private let zmLog = ZMSLog(tag: "background-activity")
             }
 
             if activities.remove(activity) != nil {
-                zmLog.debug("End background activity: removed \(activity), \(activities.count) others left. App state: \(activityManager.applicationState), time remaining: \(String(format: "%.2f", activityManager.backgroundTimeRemaining))")
+                zmLog.debug("End background activity: removed \(activity), \(activities.count) others left. \(activityManager.stateDescription)")
             } else {
                 zmLog.debug("End background activity: could not remove \(activity), \(activities.count) others left")
             }
@@ -146,7 +146,7 @@ private let zmLog = ZMSLog(tag: "background-activity")
                 return nil 
             }
             
-            zmLog.debug("Start activity [\(name)]: app state: \(activityManager.applicationState), time remaining: \(String(format: "%.2f", activityManager.backgroundTimeRemaining))")
+            zmLog.debug("Start activity [\(name)]: \(activityManager.stateDescription))")
             // Do not start new tasks if the background timer is running.
             guard currentBackgroundTask != UIBackgroundTaskInvalid else { 
                 zmLog.debug("Start activity [\(name)]: failed, currentBackgroundTask is invalid")

--- a/Source/Background/BackgroundActivityManager.swift
+++ b/Source/Background/BackgroundActivityManager.swift
@@ -36,7 +36,9 @@ import UIKit
 extension BackgroundActivityManager {
     var stateDescription: String {
         if applicationState == .background {
-            return "App state: \(applicationState), time remaining: \(String(format: "%.2f", backgroundTimeRemaining))"
+            // Sometimes time remaining is very large even if we run in background
+            let time = backgroundTimeRemaining > 100000 ? "No Limit" : String(format: "%.2f", backgroundTimeRemaining)
+            return "App state: \(applicationState), time remaining: \(time)"
         } else {
             return "App state: \(applicationState)"
         }

--- a/Source/Background/BackgroundActivityManager.swift
+++ b/Source/Background/BackgroundActivityManager.swift
@@ -33,6 +33,16 @@ import UIKit
     var applicationState: UIApplication.State { get }
 }
 
+extension BackgroundActivityManager {
+    var stateDescription: String {
+        if applicationState == .background {
+            return "App state: \(applicationState), time remaining: \(String(format: "%.2f", backgroundTimeRemaining))"
+        } else {
+            return "App state: \(applicationState)"
+        }
+    }
+}
+
 extension UIApplication.State: CustomDebugStringConvertible {
     public var debugDescription: String {
         switch self {

--- a/Source/Background/BackgroundActivityManager.swift
+++ b/Source/Background/BackgroundActivityManager.swift
@@ -28,6 +28,22 @@ import UIKit
 
     /// End the background task.
     func endBackgroundTask(_ task: UIBackgroundTaskIdentifier)
+    
+    var backgroundTimeRemaining: TimeInterval { get }
+    var applicationState: UIApplication.State { get }
+}
+
+extension UIApplication.State: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        switch self {
+        case .active:
+            return "active"
+        case .background:
+            return "background"
+        case .inactive:
+            return "inactive"
+        }
+    }
 }
 
 extension UIApplication: BackgroundActivityManager {}

--- a/Tests/Source/Helpers/MockBackgroundActivityManager.swift
+++ b/Tests/Source/Helpers/MockBackgroundActivityManager.swift
@@ -25,6 +25,10 @@ import WireTesting
  */
 
 @objc class MockBackgroundActivityManager: NSObject, BackgroundActivityManager {
+    
+    var backgroundTimeRemaining: TimeInterval = 10
+    
+    var applicationState: UIApplication.State = .active
 
     /// Whether the activity is expiring.
     @objc private(set) var isExpiring: Bool = false


### PR DESCRIPTION
## What's new in this PR?

### Issues

There were some improvements possible for background activity logging.

### Solutions

* Correctly printing the name of background task.
* Added time remaining for background processing
* Printing state of the app
* Added counter for background activities so it would be easier to match than pointer addresses used by default.

