### PR TITLE
Remove expired activities

### DIFF
--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -209,6 +209,8 @@ private let zmLog = ZMSLog(tag: "background-activity")
 
     /// Ends the current background task.
     private func finishBackgroundTask() {
+        // No need to keep any activities after finishing
+        activities.removeAll()
         if let currentBackgroundTask = self.currentBackgroundTask {
             if let activityManager = activityManager {
                 zmLog.debug("Finishing background task: \(currentBackgroundTask)")

--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -118,7 +118,7 @@ private let zmLog = ZMSLog(tag: "background-activity")
                 zmLog.debug("End activity [\(activity)]: failed, activityManager is nil")
                 return
             }
-            zmLog.debug("End background activity: removing \(activity).\(activityManager.stateDescription)")
+            zmLog.debug("End background activity: removing \(activity). \(activityManager.stateDescription)")
         }
         isolationQueue.sync {
             guard currentBackgroundTask != UIBackgroundTaskInvalid else {

--- a/Tests/Source/Background/BackgroundActivityFactoryTests.swift
+++ b/Tests/Source/Background/BackgroundActivityFactoryTests.swift
@@ -118,9 +118,9 @@ class BackgroundActivityFactoryTests: XCTestCase {
         // THEN
         waitForExpectations(timeout: 0.5, handler: nil)
         XCTAssertFalse(factory.isActive)
+        XCTAssertTrue(factory.activities.isEmpty)
         XCTAssertEqual(activityManager.numberOfTasks, 0)
-    }
-
+    }    
 }
 
 // MARK: - Helpers


### PR DESCRIPTION
## What's new in this PR?

### Issues

After studying the logs more it seems we were keeping around activities after background task expiration.

### Causes

When expiration callback was called we should clear activities set to make sure none of them stay around for a new background task.
