### PR TITLE
Go offline when detecting an unsecure connection

### DIFF
--- a/Source/Public/ZMURLSession.h
+++ b/Source/Public/ZMURLSession.h
@@ -81,6 +81,8 @@ didReceiveResponse:(NSURLResponse *)response
 
 - (void)URLSessionDidReceiveData:(ZMURLSession *)URLSession;
 
+- (void)URLSession:(ZMURLSession *)URLSession didDetectUnsafeConnectionToHost:(NSString *)host;
+
 - (void)URLSession:(ZMURLSession *)URLSession
    taskDidComplete:(NSURLSessionTask *)task
   transportRequest:(ZMTransportRequest *)transportRequest

--- a/Source/TransportSession/ZMTransportRequestScheduler.m
+++ b/Source/TransportSession/ZMTransportRequestScheduler.m
@@ -313,7 +313,6 @@ ZM_EMPTY_ASSERTING_INIT();
     }
     
     if ((errorCode == 0) ||
-        (errorCode == NSURLErrorCancelled) ||
         (errorCode == NSURLErrorTimedOut))
     {
         if (httpStatusCode == UnauthorizedStatusCode) {

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -737,6 +737,15 @@ static NSInteger const DefaultMaximumRequests = 6;
     }
 }
 
+- (void)URLSession:(ZMURLSession *)URLSession didDetectUnsafeConnectionToHost:(NSString *)host
+{
+    NOT_USED(URLSession);
+    
+    ZMLogDebug(@"Detected unsafe connection to %@", host);    
+    [self.requestScheduler setSchedulerState:ZMTransportRequestSchedulerStateOffline];
+    [self.weakNetworkStateDelegate didGoOffline];
+}
+
 @end
 
 

--- a/Source/URLSession/ZMURLSession.m
+++ b/Source/URLSession/ZMURLSession.m
@@ -296,6 +296,7 @@ ZM_EMPTY_ASSERTING_INIT();
         BOOL const didTrust = [self.trustProvider verifyServerTrustWithTrust:protectionSpace.serverTrust host:protectionSpace.host];
         if (! didTrust) {
             ZMLogDebug(@"Not trusting the server.");
+            [self.delegate URLSession:self didDetectUnsafeConnectionToHost:protectionSpace.host];
             completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
             return;
         }

--- a/Tests/Source/Helpers/MockURLAuthenticationChallengeSender.swift
+++ b/Tests/Source/Helpers/MockURLAuthenticationChallengeSender.swift
@@ -1,0 +1,36 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+@objc
+class MockURLAuthenticationChallengeSender: NSObject, URLAuthenticationChallengeSender {
+    
+    func use(_ credential: URLCredential, for challenge: URLAuthenticationChallenge) {
+        
+    }
+    
+    func continueWithoutCredential(for challenge: URLAuthenticationChallenge) {
+        
+    }
+    
+    func cancel(_ challenge: URLAuthenticationChallenge) {
+        
+    }
+    
+}

--- a/Tests/Source/Helpers/ZMMockURLSession.swift
+++ b/Tests/Source/Helpers/ZMMockURLSession.swift
@@ -51,6 +51,10 @@ import WireTransport
     func urlSessionDidReceiveData(_ URLSession: ZMURLSession) {
         // no-op
     }
+    
+    func urlSession(_ URLSession: ZMURLSession, didDetectUnsafeConnectionToHost host: String) {
+        // no-op
+    }
 
     func urlSession(_ URLSession: ZMURLSession, taskDidComplete task: URLSessionTask, transportRequest: ZMTransportRequest, responseData: Data) {
         // no-op

--- a/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -65,9 +65,13 @@ private class MockReachability: NSObject, ReachabilityProvider, TearDownCapable 
     
 }
 
+@objcMembers
 class MockCertificateTrust: NSObject, BackendTrustProvider {
+    
+    var isTrustingServer: Bool = true
+    
     func verifyServerTrust(trust: SecTrust, host: String?) -> Bool {
-        return true
+        return isTrustingServer
     }
 }
 

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -1451,6 +1451,41 @@ static XCTestCase *currentTestCase;
     XCTAssertEqualObjects(self.scheduler.processedResponses.firstObject, expected);
 }
 
+
+@end
+
+
+@implementation ZMTransportSessionTests (UnsafeConnection)
+
+- (void)testThatItTakesSchedulerOfflineWhenItDetectsAnUnsafeConnection
+{
+    // given
+    XCTAssertEqual(self.scheduler.schedulerState, ZMTransportRequestSchedulerStateNormal);
+    
+    // when
+    [self.sut URLSession:self.URLSession didDetectUnsafeConnectionToHost:@"wire.com"];
+    
+    // then
+    XCTAssertEqual(self.scheduler.schedulerState, ZMTransportRequestSchedulerStateOffline);
+}
+
+- (void)testThatItCallsDidGoOfflineWhenItDetectsAnUnsafeConnection
+{
+    // given
+    id observer = [OCMockObject mockForProtocol:@protocol(ZMNetworkStateDelegate)];
+    [[observer expect] didReceiveData];
+    self.sut.networkStateDelegate = observer;
+    
+    // expect
+    [[observer expect] didGoOffline];
+    
+    // when
+    [self.sut URLSession:self.URLSession didDetectUnsafeConnectionToHost:@"wire.com"];
+    
+    // then
+    [observer verify];
+}
+
 @end
 
 

--- a/Tests/Source/URLSession/ZMURLSessionTests.m
+++ b/Tests/Source/URLSession/ZMURLSessionTests.m
@@ -39,11 +39,12 @@
 @property (nonatomic) NSURLRequest *URLRequestB;
 
 @property (nonatomic) NSUInteger receivedDataCount;
+@property (nonatomic) NSUInteger unsafeConnectionDetectedCount;
 @property (nonatomic) NSMutableArray *receivedResponses;
 @property (nonatomic) NSMutableArray *finishedBackgroundSessions;
 @property (nonatomic) NSMutableArray *completedTasks;
 @property (nonatomic) NSMutableArray *firedTimers;
-@property (nonatomic) TestTrustProvider *trustProvider;
+@property (nonatomic) MockCertificateTrust *trustProvider;
 
 
 @end
@@ -70,7 +71,7 @@ static NSString * const DataKey = @"data";
     self.firedTimers = [NSMutableArray array];
     self.finishedBackgroundSessions = [NSMutableArray array];
     self.receivedDataCount = 0;
-    self.trustProvider = [[TestTrustProvider alloc] init];
+    self.trustProvider = [[MockCertificateTrust alloc] init];
 
     self.queue = [NSOperationQueue zm_serialQueueWithName:self.name];
     self.sut = (id) [[ZMURLSession alloc] initWithConfiguration:NSURLSessionConfiguration.defaultSessionConfiguration
@@ -92,6 +93,7 @@ static NSString * const DataKey = @"data";
     self.completedTasks = nil;
     self.finishedBackgroundSessions = nil;
     self.receivedDataCount = 0;
+    self.unsafeConnectionDetectedCount = 0;
     self.firedTimers = nil;
     [self.sut tearDown];
     self.sut = nil;
@@ -116,6 +118,13 @@ static NSString * const DataKey = @"data";
 {
     XCTAssertEqual(URLSession, self.sut);
     ++self.receivedDataCount;
+}
+
+- (void)URLSession:(ZMURLSession *)URLSession didDetectUnsafeConnectionToHost:(NSString *)host
+{
+    NOT_USED(URLSession);
+    NOT_USED(host);
+    self.unsafeConnectionDetectedCount += 1;
 }
 
 - (void)URLSession:(__unused ZMURLSession *)URLSession taskDidComplete:(NSURLSessionTask *)task transportRequest:(ZMTransportRequest *)transportRequest responseData:(NSData *)responseData;
@@ -272,6 +281,26 @@ static NSString * const DataKey = @"data";
 
 
 @implementation ZMURLSessionTests (Delegate)
+
+- (void)testItCallTheDelegateWhenItDetectsAnUnsafeConnection
+{
+    // given
+    self.trustProvider.isTrustingServer = NO;
+    
+    MockURLAuthenticationChallengeSender* sender = [[MockURLAuthenticationChallengeSender alloc] init];
+    MockEnvironment *environment = [[MockEnvironment alloc] init];
+    NSURLProtectionSpace *protectionSpace = [[NSURLProtectionSpace alloc] initWithHost:environment.backendURL.host port:443 protocol:@"https" realm:nil authenticationMethod:NSURLAuthenticationMethodServerTrust];
+    NSURLAuthenticationChallenge *challenge = [[NSURLAuthenticationChallenge alloc] initWithProtectionSpace:protectionSpace proposedCredential:nil previousFailureCount:0 failureResponse:nil error:nil sender:sender];
+    
+    // when
+    [self.sut URLSession:self.sut.backingSession didReceiveChallenge:challenge completionHandler:^(NSURLSessionAuthChallengeDisposition disposition, NSURLCredential * _Nullable credential) {
+        NOT_USED(disposition);
+        NOT_USED(credential);
+    }];
+    
+    // then
+    XCTAssertEqual(self.unsafeConnectionDetectedCount, 1);
+}
 
 - (void)testThatItCallsTheDelegateWhenItReceivesAResponse;
 {

--- a/WireTransport.xcodeproj/project.pbxproj
+++ b/WireTransport.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		09CC4AC11B7CE44900201C63 /* ZMTaskIdentifierMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 09CC4AC01B7CE44900201C63 /* ZMTaskIdentifierMap.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		09F028C61B7252FC00BADDB6 /* Lorem Ipsum.txt in Resources */ = {isa = PBXBuildFile; fileRef = 09F028C51B7252FC00BADDB6 /* Lorem Ipsum.txt */; };
 		160C31231E5B28A10012E4BC /* ZMPushChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = 160C31221E5B28A10012E4BC /* ZMPushChannel.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1650EBDD21CBFE9C00186075 /* MockURLAuthenticationChallengeSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1650EBDC21CBFE9C00186075 /* MockURLAuthenticationChallengeSender.swift */; };
 		16B685961EC0C2F80055BEA3 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16B685951EC0C2F80055BEA3 /* Security.framework */; };
 		3E88BCB31B1F35DF00232589 /* WireTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BCA71B1F35DF00232589 /* WireTransport.framework */; };
 		5431ABFF1DB4C35B0040343C /* RequestLoopDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5431ABFE1DB4C35B0040343C /* RequestLoopDetection.swift */; };
@@ -224,6 +225,7 @@
 		09F027DA1B721EBE00BADDB6 /* WireTransport.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WireTransport.xcconfig; sourceTree = "<group>"; };
 		09F028C51B7252FC00BADDB6 /* Lorem Ipsum.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "Lorem Ipsum.txt"; sourceTree = "<group>"; };
 		160C31221E5B28A10012E4BC /* ZMPushChannel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMPushChannel.h; sourceTree = "<group>"; };
+		1650EBDC21CBFE9C00186075 /* MockURLAuthenticationChallengeSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLAuthenticationChallengeSender.swift; sourceTree = "<group>"; };
 		16B685951EC0C2F80055BEA3 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/Security.framework; sourceTree = DEVELOPER_DIR; };
 		3E88BCA71B1F35DF00232589 /* WireTransport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireTransport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E88BCB21B1F35DF00232589 /* WireTransport-ios-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "WireTransport-ios-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -808,6 +810,7 @@
 				5E2C354821A5BE7B0034F1EE /* ZMMockURLSession.swift */,
 				5E2C352421A567240034F1EE /* MockBackgroundActivityManager.swift */,
 				F1D1280121C020470090045E /* MockEnvironment.swift */,
+				1650EBDC21CBFE9C00186075 /* MockURLAuthenticationChallengeSender.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1146,6 +1149,7 @@
 				546E8A031B33015000DD1042 /* ZMTransportSessionTests.m in Sources */,
 				5E2C352821A56FD50034F1EE /* BackgroundActivityFactoryTests.swift in Sources */,
 				546E89EB1B33015000DD1042 /* ZMNetworkSocketTest.m in Sources */,
+				1650EBDD21CBFE9C00186075 /* MockURLAuthenticationChallengeSender.swift in Sources */,
 				546E89EF1B33015000DD1042 /* ZMTransportPushChannelTests.m in Sources */,
 				5431AC011DB4C8330040343C /* RequestLoopDetectionTests.swift in Sources */,
 				546E89F91B33015000DD1042 /* ZMTransportRequestTests.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

App would go into a request loop if the connection to the backend couldn't be verified. This drains the battery and isn't very informative.

### Causes

When the connection can't be be verified the requests will be cancelled. The scheduler would treat this as a temporary error and immediately try again.

### Solutions

Take the scheduler offline when the connection is not secure. In the future we could a separate offline state when the connection is not secure to allow a more informative error message in the UI.
