### PR TITLE
Improve logging for background tasks

### DIFF
--- a/Source/Background/BackgroundActivity.swift
+++ b/Source/Background/BackgroundActivity.swift
@@ -29,6 +29,8 @@ fileprivate let activityCounterQueue = DispatchQueue(label: "wire-transport.back
 
     /// The name of the task, used for debugging purposes.
     @objc public let name: String
+    /// Globally unique index of background activity
+    public let index: Int
 
     /// The block of code called from the main thead when the background timer is about to expire.
     @objc public var expirationHandler: (() -> Void)?

--- a/Source/Background/BackgroundActivity.swift
+++ b/Source/Background/BackgroundActivity.swift
@@ -28,9 +28,7 @@ fileprivate let activityCounterQueue = DispatchQueue(label: "wire-transport.back
 @objc public class BackgroundActivity: NSObject {
 
     /// The name of the task, used for debugging purposes.
-    public let name: String
-    /// Globally unique index of background activity
-    public let index: Int
+    @objc public let name: String
 
     /// The block of code called from the main thead when the background timer is about to expire.
     @objc public var expirationHandler: (() -> Void)?

--- a/Source/Background/BackgroundActivity.swift
+++ b/Source/Background/BackgroundActivity.swift
@@ -28,7 +28,9 @@ fileprivate let activityCounterQueue = DispatchQueue(label: "wire-transport.back
 @objc public class BackgroundActivity: NSObject {
 
     /// The name of the task, used for debugging purposes.
-    @objc public let name: String
+    public let name: String
+    /// Globally unique index of background activity
+    public let index: Int
 
     /// The block of code called from the main thead when the background timer is about to expire.
     @objc public var expirationHandler: (() -> Void)?
@@ -37,8 +39,9 @@ fileprivate let activityCounterQueue = DispatchQueue(label: "wire-transport.back
         self.name = name
         self.expirationHandler = expirationHandler
         // Increment counter with overflow (used in .description)
-        activityCounterQueue.sync {
+        self.index = activityCounterQueue.sync {
             activityCounter &+= 1
+            return activityCounter
         }
     }
 
@@ -85,7 +88,6 @@ fileprivate let activityCounterQueue = DispatchQueue(label: "wire-transport.back
     }
     
     override public var description: String {
-        let counter = activityCounterQueue.sync { return activityCounter }
-        return "<BackgroundActivity: \(name) [\(counter)]>"
+        return "<BackgroundActivity: \(name) [\(index)]>"
     }
 }

--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -60,6 +60,7 @@ private let zmLog = ZMSLog(tag: "background-activity")
         }
     }
 
+    @objc var mainQueue: DispatchQueue = .main
     private let isolationQueue = DispatchQueue(label: "BackgroundActivityFactory.IsolationQueue")
 
     var currentBackgroundTask: UIBackgroundTaskIdentifier?

--- a/Source/Background/BackgroundActivityFactory.swift
+++ b/Source/Background/BackgroundActivityFactory.swift
@@ -60,7 +60,6 @@ private let zmLog = ZMSLog(tag: "background-activity")
         }
     }
 
-    @objc var mainQueue: DispatchQueue = .main
     private let isolationQueue = DispatchQueue(label: "BackgroundActivityFactory.IsolationQueue")
 
     var currentBackgroundTask: UIBackgroundTaskIdentifier?
@@ -113,13 +112,6 @@ private let zmLog = ZMSLog(tag: "background-activity")
      */
 
     @objc public func endBackgroundActivity(_ activity: BackgroundActivity) {
-        DispatchQueue.main.async {
-            guard let activityManager = self.activityManager else {
-                zmLog.debug("End activity [\(activity)]: failed, activityManager is nil")
-                return
-            }
-            zmLog.debug("End background activity: removing \(activity). \(activityManager.stateDescription)")
-        }
         isolationQueue.sync {
             guard currentBackgroundTask != UIBackgroundTaskInvalid else {
                 zmLog.debug("End background activity: current background task is invalid")
@@ -143,13 +135,6 @@ private let zmLog = ZMSLog(tag: "background-activity")
 
     /// Starts the background activity of the system allows it.
     private func startActivityIfPossible(_ name: String, _ expirationHandler: (() -> Void)?) -> BackgroundActivity? {
-        DispatchQueue.main.async {
-            guard let activityManager = self.activityManager else {
-                zmLog.debug("Start activity [\(name)]: failed, activityManager is nil")
-                return
-            }
-            zmLog.debug("Start activity [\(name)]: \(activityManager.stateDescription)")
-        }
         return isolationQueue.sync {
             guard let activityManager = activityManager else {
                 zmLog.debug("Start activity [\(name)]: failed, activityManager is nil")
@@ -193,7 +178,7 @@ private let zmLog = ZMSLog(tag: "background-activity")
             return
         }
         
-        zmLog.debug("Handle expiration: \(activityManager.description)")
+        zmLog.debug("Handle expiration: \(activityManager.stateDescription)")
         let activities = isolationQueue.sync {
             return self.activities
         }


### PR DESCRIPTION
## What's new in this PR?

### Issues

The counter that should be unique for each new background task was not working correctly.

### Solutions

Save the counter value after incrementing instead of reading the static value. Also removed some logging on main queue because it was out of sync with the rest of log entries.
