### PR TITLE
ZIOS-11351: Read password rules from Backend bundle

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "wireapp/wire-ios-utilities" ~> 29.0
+github "wireapp/wire-ios-utilities" "feature/password-validation"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "wireapp/ocmock" "v3.4.3"
 github "wireapp/wire-ios-system" "26.0.1"
 github "wireapp/wire-ios-testing" "18.0.0"
-github "wireapp/wire-ios-utilities" "29.0.0"
+github "wireapp/wire-ios-utilities" "3f0ca81f41410e22c3b1d55e958c013909040185"

--- a/Source/Public/BackendEnvironment.swift
+++ b/Source/Public/BackendEnvironment.swift
@@ -55,7 +55,7 @@ public class BackendEnvironment: NSObject {
     let endpoints: BackendEndpointsProvider
     let certificateTrust: BackendTrustProvider
 
-    /// passwordRules
+    /// The rules to create new passwords.
     public let passwordRules: PasswordRuleSet
     
     init(endpoints: BackendEndpointsProvider, certificateTrust: BackendTrustProvider, passwordRules: PasswordRuleSet) {

--- a/Source/Public/PasswordRules+Default.swift
+++ b/Source/Public/PasswordRules+Default.swift
@@ -1,0 +1,28 @@
+//
+// Wire
+// Copyright (C) 2018 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import WireUtilities
+
+extension PasswordRuleSet {
+
+    /// The default rule set to use when none is specified.
+    public static var `default`: PasswordRuleSet {
+        return PasswordRuleSet(minimumLength: 8, maximumLength: 120, allowedCharacters: [.unicode], requiredCharacters: [.digits, .uppercase, .lowercase, .special])
+    }
+
+}

--- a/Tests/Resources/Backend.bundle/production.json
+++ b/Tests/Resources/Backend.bundle/production.json
@@ -32,5 +32,15 @@
                 }
             ]
         }
-    ]
+    ],
+    "password_rules": {
+        "minimum-length": 12,
+        "maximum-length": 200,
+        "allowed-characters": [
+            "unicode"
+        ],
+        "required-characters": [
+            "digits"
+        ]
+    }
 }

--- a/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -86,7 +86,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         sessionMock = MockURLSession()
         let endpoints = BackendEndpoints(backendURL: url, backendWSURL: url, blackListURL: url, frontendURL: url)
         let trust = MockCertificateTrust()
-        let environment = BackendEnvironment(endpoints: endpoints, certificateTrust: trust)
+        let environment = BackendEnvironment(endpoints: endpoints, certificateTrust: trust, passwordRules: .default)
         sut = UnauthenticatedTransportSession(environment: environment,
                                               urlSession: sessionMock,
                                               reachability: MockReachability())

--- a/Tests/Source/URLSession/BackendEnvironmentTests.swift
+++ b/Tests/Source/URLSession/BackendEnvironmentTests.swift
@@ -74,4 +74,24 @@ class BackendEnvironmentTests: XCTestCase {
         XCTAssertEqual(trust.trustData.count, 0, "We should not have any keys")
     }
 
+    func testThatWeCanLoadPasswordRules() {
+        guard let environment = BackendEnvironment.from(environmentType: .production, configurationBundle: backendBundle) else { XCTFail("Could not read environment data from Backend.bundle"); return }
+        let passwordRules = environment.passwordRules
+
+        XCTAssertEqual(passwordRules.minimumLength, 12)
+        XCTAssertEqual(passwordRules.maximumLength, 200)
+        XCTAssertEqual(Set(passwordRules.requiredCharacterSets.keys), [.digits])
+        XCTAssertEqual(passwordRules.allowedCharacters, [.unicode, .digits])
+    }
+
+    func testThatWeFallbackToDefaultPasswordRulesIfTheyAreNotInTheBundle() {
+        guard let environment = BackendEnvironment.from(environmentType: .staging, configurationBundle: backendBundle) else { XCTFail("Could not read environment data from Backend.bundle"); return }
+        let passwordRules = environment.passwordRules
+
+        XCTAssertEqual(passwordRules.minimumLength, 8)
+        XCTAssertEqual(passwordRules.maximumLength, 120)
+        XCTAssertEqual(Set(passwordRules.requiredCharacterSets.keys), [.digits, .lowercase, .uppercase, .special])
+        XCTAssertEqual(passwordRules.allowedCharacters, [.unicode, .digits, .lowercase, .uppercase, .special])
+    }
+
 }

--- a/WireTransport.xcodeproj/project.pbxproj
+++ b/WireTransport.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		5E2C352621A567600034F1EE /* MockBackgroundActivityManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2C352421A567240034F1EE /* MockBackgroundActivityManager.swift */; };
 		5E2C352821A56FD50034F1EE /* BackgroundActivityFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2C352721A56FD50034F1EE /* BackgroundActivityFactoryTests.swift */; };
 		5E2C354921A5BE7B0034F1EE /* ZMMockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2C354821A5BE7B0034F1EE /* ZMMockURLSession.swift */; };
+		5E39FC5D225B910200C682B8 /* PasswordRules+Default.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E39FC5C225B910200C682B8 /* PasswordRules+Default.swift */; };
 		5EAC173521A44FB90014E671 /* BackgroundActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAC173421A44FB90014E671 /* BackgroundActivity.swift */; };
 		7C5496DE20A0880C001A9D87 /* ZMTransportRequestLoggingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C5496DC20A085FA001A9D87 /* ZMTransportRequestLoggingTests.swift */; };
 		870F5E671FBF24AD004841E3 /* NetworkSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 870F5E661FBF24AD004841E3 /* NetworkSocket.swift */; };
@@ -328,6 +329,7 @@
 		5E2C352421A567240034F1EE /* MockBackgroundActivityManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockBackgroundActivityManager.swift; sourceTree = "<group>"; };
 		5E2C352721A56FD50034F1EE /* BackgroundActivityFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundActivityFactoryTests.swift; sourceTree = "<group>"; };
 		5E2C354821A5BE7B0034F1EE /* ZMMockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMMockURLSession.swift; sourceTree = "<group>"; };
+		5E39FC5C225B910200C682B8 /* PasswordRules+Default.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PasswordRules+Default.swift"; sourceTree = "<group>"; };
 		5EAC173421A44FB90014E671 /* BackgroundActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundActivity.swift; sourceTree = "<group>"; };
 		7C5496DC20A085FA001A9D87 /* ZMTransportRequestLoggingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZMTransportRequestLoggingTests.swift; sourceTree = "<group>"; };
 		870F5E661FBF24AD004841E3 /* NetworkSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkSocket.swift; sourceTree = "<group>"; };
@@ -722,6 +724,7 @@
 				871667FF1BB2CD2A009C6EEA /* ZMKeychain.h */,
 				160C31221E5B28A10012E4BC /* ZMPushChannel.h */,
 				8756C4492178C97A00627F1F /* BackendEnvironment.swift */,
+				5E39FC5C225B910200C682B8 /* PasswordRules+Default.swift */,
 				F1D1281D21C2656F0090045E /* ServerCertificateTrust.swift */,
 				F1D1281F21C2665E0090045E /* BackendEndpoints.swift */,
 				F1D1281621C1556D0090045E /* BackendEnvironmentProvider.swift */,
@@ -1090,6 +1093,7 @@
 				F1D1281E21C2656F0090045E /* ServerCertificateTrust.swift in Sources */,
 				CE3677691D48B4BA00A8015A /* BackgroundActivityFactory.swift in Sources */,
 				095840201B9591F1004555F9 /* NSData+Multipart.m in Sources */,
+				5E39FC5D225B910200C682B8 /* PasswordRules+Default.swift in Sources */,
 				54CA15551B32F2C1008D3787 /* ZMPersistentCookieStorage.m in Sources */,
 				F1D1281921C1556E0090045E /* TrustData.swift in Sources */,
 				5EAC173521A44FB90014E671 /* BackgroundActivity.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

We introduced customizable password rules with https://github.com/wireapp/wire-ios-utilities/pull/76, and need to allow their customization from the Backend bundle file.

### Solutions

Add the necessary deserialization and tests to the BackendEnvironment structure.

### Dependencies

_Needs release with:_

- [ ] https://github.com/wireapp/wire-ios-utilities/pull/76