### PR TITLE
Fix: iOS 13 - dateForKey method always return nil

### DIFF
--- a/Source/Public/Collections+ZMSafeTypes.swift
+++ b/Source/Public/Collections+ZMSafeTypes.swift
@@ -102,10 +102,11 @@ extension NSDictionary {
         return optionalObjectWhichIsKindOfClass(dictionary: self, key: key){UUID(uuidString:$0)}
     }
     
-    @objc public func date(forKey key: String) -> Date? {
+    @objc
+    public func date(for key: String) -> Date? {
         return requiredObjectWhichIsKindOfClass(dictionary: self, key: key) { NSDate(transport: $0) as Date? }
     }
-    
+
     @objc public func optionalDate(forKey key: String) -> Date? {
         return optionalObjectWhichIsKindOfClass(dictionary: self, key: key) { NSDate(transport: $0) as Date? }
     }

--- a/Source/TransportEncoding/NSObject+ZMTransportEncoding.m
+++ b/Source/TransportEncoding/NSObject+ZMTransportEncoding.m
@@ -41,6 +41,7 @@ static locale_t posixLocale()
 
 @implementation NSDate (ZMTransportEncoding)
 
+///TODO: review this method for iOS 13 beta, can we retire below 2 methods?
 + (instancetype)dateWithTransportString:(NSString *)transportString;
 {
     struct {

--- a/Tests/Source/TransportEncoding/Collections+ZMTSafeTypesTests.m
+++ b/Tests/Source/TransportEncoding/Collections+ZMTSafeTypesTests.m
@@ -86,9 +86,9 @@
 
 - (void)testThatItReadsADate {
     NSString *key = @"date";
-    XCTAssertEqualObjects([NSDate dateWithTransportString:self.sampleDictionary[key]], [self.sampleDictionary dateForKey:key]);
-    XCTAssertNil([self.sampleDictionary dateForKey:@"baz"]);
-    XCTAssertNil([self.sampleDictionary dateForKey:@"string"]);
+    XCTAssertEqualObjects([NSDate dateWithTransportString:self.sampleDictionary[key]], [self.sampleDictionary dateFor:key]);
+    XCTAssertNil([self.sampleDictionary dateFor:@"baz"]);
+    XCTAssertNil([self.sampleDictionary dateFor:@"string"]);
 }
 
 - (void)testThatItReadsAUUID {
@@ -390,10 +390,13 @@
     NSDictionary *dict = @{ @"foo" : dateString };
     
     // when
-    id value = [dict dateForKey:@"foo"];
-    
+//    id value = [dict optionaldateFor:@"foo"]; ///TODO: optional?
+    id value = [dict dateFor:@"foo"]; ///TODO: can not jump in?
+//    id value = [
+
     // then
     XCTAssertNotNil(value);
+//    XCTAssertNotNil(value);
     XCTAssertEqualObjects(value, testValue);
 }
 
@@ -405,7 +408,7 @@
     NSDictionary *dict = @{ @"foo" : testValue };
     
     // when
-    id value = [dict dateForKey:@"foo"];
+    id value = [dict dateFor:@"foo"];
     
     // then
     XCTAssertNotNil(value);
@@ -418,7 +421,7 @@
     NSDictionary *dict = @{ @"foo" : @"dog" };
     
     // when
-    id value = [dict dateForKey:@"foo"];
+    id value = [dict dateFor:@"foo"];
     
     // then
     XCTAssertNil(value);
@@ -430,7 +433,7 @@
     NSDictionary *dict = @{ @"foo" : @3 };
     
     // when
-    id value = [dict dateForKey:@"foo"];
+    id value = [dict dateFor:@"foo"];
     
     // then
     XCTAssertNil(value);
@@ -442,7 +445,7 @@
     NSDictionary *dict = @{ };
     
     // when
-    id value = [dict dateForKey:@"bar"];
+    id value = [dict dateFor:@"bar"];
     
     // then
     XCTAssertNil(value);


### PR DESCRIPTION
## What's new in this PR?

### Issues

On iOS 13 device, `dateForKey` of `NSDictionary` always return nil. 

### Causes

Unknown, may be related to API changes.

### Solutions

rename the method to `dateFor` (for obj-c interface)