### PR TITLE
Add authenticationCookieExpirationDate to the cookie storage

### DIFF
--- a/Source/Public/ZMPersistentCookieStorage.h
+++ b/Source/Public/ZMPersistentCookieStorage.h
@@ -39,6 +39,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /// Delete all keychain items for current the user and server
 - (void)deleteKeychainItems;
+    
+/// Date and time when the authentication cookie is no longer valid
+@property (nonatomic, nullable) NSDate *authenticationCookieExpirationDate;
 
 /// Authentication cookie available in the storage
 @property (nonatomic, nullable) NSData *authenticationCookieData;

--- a/Tests/Source/Authentication/ZMPersistentCookieStorageTests.m
+++ b/Tests/Source/Authentication/ZMPersistentCookieStorageTests.m
@@ -279,8 +279,29 @@
     XCTAssertEqualObjects([request valueForHTTPHeaderField:@"Cookie"],
                           @"zuid=wjCWn1Y1pBgYrFCwuU7WK2eHpAVY8Ocu-rUAWIpSzOcvDVmYVc9Xd6Ovyy-PktFkamLushbfKgBlIWJh6ZtbAA==.1721442805.u.7eaaa023.08326f5e-3c0f-4247-a235-2b4d93f921a4");
 }
-
-
+    
+- (void)testThatWeRetrieveCookieExpirationDate
+{
+    // given
+    XCTAssertNil(self.sut.authenticationCookieData);
+    
+    NSDictionary *headerFields = @{@"Date": @"Thu, 24 Jul 2014 09:06:45 GMT",
+                                   @"Content-Encoding": @"gzip",
+                                   @"Server": @"nginx",
+                                   @"Content-Type": @"application/json",
+                                   @"Access-Control-Allow-Origin": @"file://",
+                                   @"Connection": @"keep-alive",
+                                   @"Set-Cookie": @"zuid=wjCWn1Y1pBgYrFCwuU7WK2eHpAVY8Ocu-rUAWIpSzOcvDVmYVc9Xd6Ovyy-PktFkamLushbfKgBlIWJh6ZtbAA==.1721442805.u.7eaaa023.08326f5e-3c0f-4247-a235-2b4d93f921a4; Expires=Sun, 21-Jul-2024 09:06:45 GMT; Domain=wire.com; HttpOnly; Secure",
+                                   @"Content-Length": @"214"};
+    NSURL *URL = [NSURL URLWithString:@"https://zeta.example.com/login"];
+    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headerFields];
+    [self.sut setCookieDataFromResponse:response forURL:URL];
+    XCTAssertNotNil(self.sut.authenticationCookieData);
+    
+    // when
+    NSISO8601DateFormatter *dateFormatter = [[NSISO8601DateFormatter alloc] init];
+    XCTAssertEqualObjects([dateFormatter stringFromDate:self.sut.authenticationCookieExpirationDate], @"2024-07-21T09:06:45Z");
+}
 
 - (void)testThatItDoesNotSetACookieDataIfNewCookieIsInvalid;
 {


### PR DESCRIPTION
## What's new in this PR?

Add `authenticationCookieExpirationDate` to the `ZMPersistentCookieStorage` to allow us to validate cookies without contacting the server.