### PR TITLE
Fix: UnauthenticatedTransportSession should be ephemeral

### DIFF
--- a/Source/TransportSession/UnauthenticatedTransportSession.swift
+++ b/Source/TransportSession/UnauthenticatedTransportSession.swift
@@ -81,7 +81,7 @@ final public class UnauthenticatedTransportSession: NSObject, UnauthenticatedTra
         self.environment = environment
         self.reachability = reachability
         super.init()
-        self.session = urlSession ?? URLSession(configuration: .default, delegate: self, delegateQueue: nil)
+        self.session = urlSession ?? URLSession(configuration: .ephemeral, delegate: self, delegateQueue: nil)
     }
 
     /// Creates and resumes a request on the internal `URLSession`.


### PR DESCRIPTION
## What's new in this PR?

### Issues

There's no need for `UnauthenticatedTransportSession` to use a default session.

### Solutions

Configure it as ephemeral