### PR TITLE
[Feature] Add enqueueOneTime() to to unauthenticated transport session

### DIFF
--- a/Source/TransportSession/UnauthenticatedTransportSession.swift
+++ b/Source/TransportSession/UnauthenticatedTransportSession.swift
@@ -23,6 +23,7 @@ public enum EnqueueResult {
 
 public protocol UnauthenticatedTransportSessionProtocol: TearDownCapable {
 
+    func enqueueOneTime(_ request: ZMTransportRequest)
     func enqueueRequest(withGenerator generator: ZMTransportRequestGenerator) -> EnqueueResult
     func tearDown()
     
@@ -83,6 +84,17 @@ final public class UnauthenticatedTransportSession: NSObject, UnauthenticatedTra
         super.init()
         self.session = urlSession ?? URLSession(configuration: .ephemeral, delegate: self, delegateQueue: nil)
     }
+    
+    
+    /// Enqueues a single request on the internal `URLSession`.
+    ///
+    /// - parameter request: Request which should be enqueued.
+    ///
+    /// The concurrent request limit does apply to when using this method
+    public func enqueueOneTime(_ request: ZMTransportRequest) {
+        _ = increment()
+        enqueueRequest(request)
+    }
 
     /// Creates and resumes a request on the internal `URLSession`.
     /// If there are too many requests in progress no request will be enqueued.
@@ -101,11 +113,18 @@ final public class UnauthenticatedTransportSession: NSObject, UnauthenticatedTra
             decrement(notify: false)
             return .nilRequest
         }
+        
+        enqueueRequest(request)
 
+        return .success
+    }
+    
+    @discardableResult
+    private func enqueueRequest(_ request: ZMTransportRequest) -> DataTaskProtocol {
         guard let urlRequest = URL(string: request.path, relativeTo: baseURL).flatMap(NSMutableURLRequest.init) else { preconditionFailure() }
         urlRequest.configure(with: request)
         request.log()
-
+        
         let task = session.task(with: urlRequest as URLRequest) { [weak self] data, response, error in
             
             var transportResponse: ZMTransportResponse!
@@ -125,9 +144,10 @@ final public class UnauthenticatedTransportSession: NSObject, UnauthenticatedTra
             request.complete(with: transportResponse)
             self?.decrement(notify: true)
         }
-
+        
         task.resume()
-        return .success
+        
+        return task
     }
 
     /// Decrements the number of running requests and posts a new

--- a/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -97,6 +97,33 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         sut = nil
         super.tearDown()
     }
+    
+    func testThatEnqueueOneTime_IncrementsTheRequestCounter() {
+        // when
+        (0..<3).forEach { _ in
+            sut.enqueueOneTime(.init(getFromPath: "/"))
+        }
+        
+        // then
+        let result = sut.enqueueRequest { .init(getFromPath: "/") }
+        XCTAssertEqual(result, .maximumNumberOfRequests)
+    }
+    
+    func testThatEnqueueOneTime_IsNotLimitedByRequestLimit() {
+        // given
+        (0..<3).forEach { _ in
+            sut.enqueueOneTime(.init(getFromPath: "/"))
+        }
+        
+        let task = MockTask()
+        sessionMock.nextMockTask = task
+        
+        // when
+        sut.enqueueOneTime(.init(getFromPath: "/"))
+        
+        // then
+        XCTAssertEqual(task.resumeCallCount, 1)
+    }
 
     func testThatItEnqueuesANonNilRequestAndReturnsTheCorrectResult() {
         // given


### PR DESCRIPTION
## What's new in this PR?

Add `enqueueOneTime(_ request: ZMTransportRequest)` to the unauthenticated transport session, which provides a way to perform single requests outside of the normal operation loop. This function already exists on the regular transport session.