### PR TITLE
[Fix] WebSocket implementation not conforming to the RFC

### DIFF
--- a/Source/PushChannel/ZMWebSocketFrame.m
+++ b/Source/PushChannel/ZMWebSocketFrame.m
@@ -159,10 +159,16 @@ typedef union websocket_header_t {
             .rsv3    = 0,
             .fin     = 1, // single frame
             .payload = 0,
-            .mask    = 0,
+            .mask    = 1,
         }
     };
-    return dispatch_data_create(&wshead, sizeof(wshead), NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    
+    uint32_t const maskingKey = 0; // Unused since we don't send any payload but included for conformance.
+    
+    dispatch_data_t h1 = dispatch_data_create(&wshead, sizeof(wshead), NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    dispatch_data_t h2 = dispatch_data_create(&maskingKey, sizeof(maskingKey), NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    
+    return dispatch_data_create_concat(h1, h2);
 }
 
 - (dispatch_data_t)pingFrameData;
@@ -175,10 +181,16 @@ typedef union websocket_header_t {
             .rsv3    = 0,
             .fin     = 1, // single frame
             .payload = 0,
-            .mask    = 0,
+            .mask    = 1,
         }
     };
-    return dispatch_data_create(&wshead, sizeof(wshead), NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    
+    uint32_t const maskingKey = 0; // Unused since we don't send any payload but included for conformance.
+    
+    dispatch_data_t h1 = dispatch_data_create(&wshead, sizeof(wshead), NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    dispatch_data_t h2 = dispatch_data_create(&maskingKey, sizeof(maskingKey), NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    
+    return dispatch_data_create_concat(h1, h2);
 }
 
 - (dispatch_data_t)frameData;

--- a/Tests/Source/PushChannel/ZMWebSocketTests.m
+++ b/Tests/Source/PushChannel/ZMWebSocketTests.m
@@ -155,8 +155,8 @@
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5 handler:nil]);
     WaitForAllGroupsToBeEmpty(0.5);
     
-    dispatch_data_t pingData = dispatch_data_create(((uint8_t []){0x89, 0}), 2, NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
-    dispatch_data_t pongData = dispatch_data_create(((uint8_t []){0x8a, 0}), 2, NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    dispatch_data_t pingData = dispatch_data_create(((uint8_t []){0x89, 0x80, 0x00, 0x00, 0x00, 0x00}), 6, NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    dispatch_data_t pongData = dispatch_data_create(((uint8_t []){0x8a, 0x80, 0x00, 0x00, 0x00, 0x00}), 6, NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
     
     // expect
     [(NetworkSocket *)[(id) self.networkSocketMock expect] writeData:(NSData *)pongData];
@@ -184,7 +184,7 @@
     XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0.5]);
     WaitForAllGroupsToBeEmpty(0.5);
     
-    dispatch_data_t pingData = dispatch_data_create(((uint8_t []){0x89, 0}), 2, NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
+    dispatch_data_t pingData = dispatch_data_create(((uint8_t []){0x89, 0x80, 0x00, 0x00, 0x00, 0x00}), 6, NULL, DISPATCH_DATA_DESTRUCTOR_DEFAULT);
     
     // expect
     [(NetworkSocket *)[(id) self.networkSocketMock expect] writeData:(NSData *)pingData];


### PR DESCRIPTION
## What's new in this PR?

### Issues

Some web socket servers were not letting the iOS client establish a WebSocket connection.

### Causes

The WebSocket specification says that all frames sent a by client must have the `mask` bit set to `1`, if not the server must close the connection.

https://tools.ietf.org/html/rfc6455#section-5.1

The iOS client does not send any data over the WebSocket, except for the control frames (ping & pong). Even though we don't send any data with these control frames the `mask` bit must still be 1 to comply with the specification.

### Solutions

Set the `mask` bit to 1 for ping and pong frames. When the `mask` bit is set to `1` we also must include a [masking key](https://tools.ietf.org/html/rfc6455#section-5.2), but since we never include any payload I'm leaving it blank.

I choose not to implement masking for the sending of binary and text frames, since we don't use them it would require me to write a lot of tests. In the future we should consider removing those methods or switch to another WebSocket framework.