### PR TITLE
Update BackendEnvironment

### DIFF
--- a/Source/Public/BackendEnvironment+Defaults.swift
+++ b/Source/Public/BackendEnvironment+Defaults.swift
@@ -22,8 +22,8 @@ extension BackendEnvironment {
 
     static let defaultsKey = "ZMBackendEnvironmentData"
 
-    public convenience init?(userDefaults: UserDefaults, configurationBundle: Bundle) {
-        let environmentType = EnvironmentType(userDefaults: userDefaults)
+    public convenience init?(userDefaults: UserDefaults, configurationBundle: Bundle, environmentType type: EnvironmentType? = nil) {
+        let environmentType = type ?? EnvironmentType(userDefaults: userDefaults)
         switch environmentType {
         case .production, .staging:
             guard let path = configurationBundle.path(forResource: environmentType.stringValue, ofType: "json") else {

--- a/Source/Public/BackendEnvironment.swift
+++ b/Source/Public/BackendEnvironment.swift
@@ -34,7 +34,7 @@ public enum EnvironmentType: Equatable {
         }
     }
 
-    init(stringValue: String) {
+    public init(stringValue: String) {
         switch stringValue {
         case EnvironmentType.staging.stringValue:
             self = .staging


### PR DESCRIPTION
## What's new in this PR?

### Issues

UI needs to be able to create a `BackendEnvironment` with using an environment type passed as a `String`

### Solutions

- Expose the `init(stringValue: String)` of `EnvironmentType`
- Add optional parameter `EnvironmentType` to `BackendEnvironment` init
