### PR TITLE
Expose the requestLoopDetectionCallback on the TransportSessionType

### DIFF
--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -74,7 +74,7 @@ extern NSString * const ZMTransportSessionNewRequestAvailableNotification;
 @property (nonatomic, assign) NSInteger maximumConcurrentRequests;
 @property (nonatomic, readonly) ZMPersistentCookieStorage *cookieStorage;
 @property (nonatomic, readonly) id<URLSessionsDirectory, TearDownCapable> sessionsDirectory;
-@property (nonatomic, copy) void (^requestLoopDetectionCallback)(NSString*);
+@property (nonatomic, copy, nullable) void (^requestLoopDetectionCallback)(NSString*);
 @property (nonatomic, readonly) id<ReachabilityProvider, TearDownCapable> reachability;
 
 - (instancetype)initWithEnvironment:(id<BackendEnvironmentProvider>)environment

--- a/Source/TransportSession/TransportSession.swift
+++ b/Source/TransportSession/TransportSession.swift
@@ -27,6 +27,8 @@ public protocol TransportSessionType: class, ZMBackgroundable, ZMRequestCancella
     
     var cookieStorage: ZMPersistentCookieStorage { get }
     
+    var requestLoopDetectionCallback: ((_ path: String) -> Void)? { get set }
+    
     @objc(enqueueOneTimeRequest:) 
     func enqueueOneTime(_ request: ZMTransportRequest)
     


### PR DESCRIPTION
## What's new in this PR?

Expose the `requestLoopDetectionCallback` on the `TransportSessionType`.