### PR TITLE
[Fix] Attempt to fix race condition when shutting an account

### DIFF
--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -293,6 +293,9 @@ static NSInteger const DefaultMaximumRequests = 6;
         [self.sessionsDirectory tearDown];
         [self.workGroup leave];
     }];
+    
+    // Wait until all the requests have been cancelled
+    [self.workQueue waitUntilAllOperationsAreFinished];
 }
 
 #if DEBUG


### PR DESCRIPTION
## What's new in this PR?

### Issues

We are seeing crashes triggered by a precondition that assert that we are executing on the correct managed object context.

example:
`[ZMMissingUpdateEventsTranscoder updateServerTimeDeltaWithTimestamp:]`

### Causes

We suspect that the managed object context on which the `ZMMissingUpdateEventsTranscoder` operates has already been torn down when the request response arrives. When the context is torn down the keys in the `userInfo` are removed, which causes the `precondition(zm_isSyncContext)` to fail.

### Solutions

Wait until all the requests have been canceled before we remove the `userInfo` keys.