### PR TITLE
[Feature]: Move RequestAvailableNotification from request-strategy

### DIFF
--- a/Source/Requests/RequestAvailableNotification.swift
+++ b/Source/Requests/RequestAvailableNotification.swift
@@ -1,0 +1,47 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+
+
+private let RequestsAvailableNotificationName = "RequestAvailableNotification"
+
+
+@objc(ZMRequestAvailableObserver) public protocol RequestAvailableObserver : NSObjectProtocol {
+    
+    func newRequestsAvailable()
+    
+}
+
+/// ZMRequestAvailableNotification is used by transport to signal the operation loop that
+/// there are new potential requests available to process.
+@objc(ZMRequestAvailableNotification) public class RequestAvailableNotification : NSObject {
+    
+    @objc public static func notifyNewRequestsAvailable(_ sender: NSObjectProtocol?) {
+        NotificationCenter.default.post(name: Notification.Name(rawValue: RequestsAvailableNotificationName), object: nil)
+    }
+    
+    @objc public static func addObserver(_ observer: RequestAvailableObserver) {
+        NotificationCenter.default.addObserver(observer, selector: #selector(RequestAvailableObserver.newRequestsAvailable), name: NSNotification.Name(rawValue: RequestsAvailableNotificationName), object: nil)
+    }
+    
+    @objc public static func removeObserver(_ observer: RequestAvailableObserver) {
+        NotificationCenter.default.removeObserver(observer, name: NSNotification.Name(rawValue: RequestsAvailableNotificationName), object: nil)
+    }
+    
+}

--- a/Tests/Source/Requests/RequestAvailableNotificationTests.swift
+++ b/Tests/Source/Requests/RequestAvailableNotificationTests.swift
@@ -1,0 +1,73 @@
+//
+// Wire
+// Copyright (C) 2016 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import XCTest
+@testable import WireTransport
+
+@objc class NotificationObserver : NSObject, RequestAvailableObserver {
+    
+    var requestsAvailable = false
+    
+    func newRequestsAvailable() {
+        requestsAvailable = true
+    }
+    
+}
+
+class RequestAvailableNotificationTests: XCTestCase {
+    
+    var sut = NotificationObserver()
+    
+    override func setUp() {
+        super.setUp()
+        
+        sut = NotificationObserver()
+    }
+    
+    override func tearDown() {
+        RequestAvailableNotification.removeObserver(sut)
+        
+        super.tearDown()
+    }
+    
+    func testObserverIsReceivingNotificationsAfterSubscribing() {
+        
+        // given
+        RequestAvailableNotification.addObserver(sut)
+        
+        // when
+        RequestAvailableNotification.notifyNewRequestsAvailable(self)
+        
+        // then 
+        XCTAssertTrue(sut.requestsAvailable)
+    }
+    
+    func testObserverIsNotReceivingNotificationsAfterUnsubscribing() {
+        
+        // given
+        RequestAvailableNotification.addObserver(sut)
+        RequestAvailableNotification.removeObserver(sut)
+        
+        // when
+        RequestAvailableNotification.notifyNewRequestsAvailable(self)
+        
+        // then
+        XCTAssertFalse(sut.requestsAvailable)
+    }
+    
+}

--- a/WireTransport.xcodeproj/project.pbxproj
+++ b/WireTransport.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		5499FFDC1B31C66D00835C8B /* ZMWebSocketHandshake.h in Headers */ = {isa = PBXBuildFile; fileRef = 5499FF7D1B31C66C00835C8B /* ZMWebSocketHandshake.h */; };
 		5499FFDE1B31C66D00835C8B /* ZMWebSocketHandshake.m in Sources */ = {isa = PBXBuildFile; fileRef = 5499FF7E1B31C66C00835C8B /* ZMWebSocketHandshake.m */; };
 		54B4D9E11E840C7E00F2892B /* NSURLSessionConfiguration+Debugging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54B4D9E01E840C7E00F2892B /* NSURLSessionConfiguration+Debugging.swift */; };
+		54C3EC5F243E2988000B9230 /* RequestAvailableNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C3EC5E243E2988000B9230 /* RequestAvailableNotification.swift */; };
+		54C3EC6F243E3517000B9230 /* RequestAvailableNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54C3EC6E243E3516000B9230 /* RequestAvailableNotificationTests.swift */; };
 		54CA15511B32F2C1008D3787 /* ZMAccessTokenHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 54CA15001B32F2C1008D3787 /* ZMAccessTokenHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		54CA15531B32F2C1008D3787 /* ZMAccessTokenHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 54CA15011B32F2C1008D3787 /* ZMAccessTokenHandler.m */; };
 		54CA15551B32F2C1008D3787 /* ZMPersistentCookieStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 54CA15021B32F2C1008D3787 /* ZMPersistentCookieStorage.m */; };
@@ -281,6 +283,8 @@
 		54BD49FB1D41FE0B006E29D1 /* Cartfile.private */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.private; sourceTree = "<group>"; };
 		54BD49FC1D41FE0B006E29D1 /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
 		54BD49FD1D41FE0B006E29D1 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
+		54C3EC5E243E2988000B9230 /* RequestAvailableNotification.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestAvailableNotification.swift; sourceTree = "<group>"; };
+		54C3EC6E243E3516000B9230 /* RequestAvailableNotificationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestAvailableNotificationTests.swift; sourceTree = "<group>"; };
 		54CA15001B32F2C1008D3787 /* ZMAccessTokenHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZMAccessTokenHandler.h; sourceTree = "<group>"; };
 		54CA15011B32F2C1008D3787 /* ZMAccessTokenHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMAccessTokenHandler.m; sourceTree = "<group>"; };
 		54CA15021B32F2C1008D3787 /* ZMPersistentCookieStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMPersistentCookieStorage.m; sourceTree = "<group>"; };
@@ -569,6 +573,7 @@
 				546E89D11B33015000DD1042 /* ZMTaskIdentifierMapTests.m */,
 				546E89D21B33015000DD1042 /* ZMTransportRequestTests.m */,
 				546E89D31B33015000DD1042 /* ZMTransportResponseTests.m */,
+				54C3EC6E243E3516000B9230 /* RequestAvailableNotificationTests.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -750,6 +755,7 @@
 				54CA15381B32F2C1008D3787 /* ZMTransportRequest.m */,
 				54CA15391B32F2C1008D3787 /* ZMTransportResponse.m */,
 				54CA153A1B32F2C1008D3787 /* ZMUserAgent.m */,
+				54C3EC5E243E2988000B9230 /* RequestAvailableNotification.swift */,
 			);
 			path = Requests;
 			sourceTree = "<group>";
@@ -1073,6 +1079,7 @@
 				54CA155D1B32F2C1008D3787 /* ZMTemporaryFileListForBackgroundRequests.m in Sources */,
 				F91EAAC81D8860380010ACBE /* Collections+ZMSafeTypes.swift in Sources */,
 				871667FE1BB2CD1E009C6EEA /* ZMKeychain.m in Sources */,
+				54C3EC5F243E2988000B9230 /* RequestAvailableNotification.swift in Sources */,
 				5499FFD61B31C66D00835C8B /* ZMWebSocket.m in Sources */,
 				F1D1282021C2665E0090045E /* BackendEndpoints.swift in Sources */,
 				870F5E671FBF24AD004841E3 /* NetworkSocket.swift in Sources */,
@@ -1140,6 +1147,7 @@
 				54EA3E6D1BEA65B80071592B /* Fakes.m in Sources */,
 				546E8A031B33015000DD1042 /* ZMTransportSessionTests.m in Sources */,
 				5E2C352821A56FD50034F1EE /* BackgroundActivityFactoryTests.swift in Sources */,
+				54C3EC6F243E3517000B9230 /* RequestAvailableNotificationTests.swift in Sources */,
 				546E89EB1B33015000DD1042 /* ZMNetworkSocketTest.m in Sources */,
 				1650EBDD21CBFE9C00186075 /* MockURLAuthenticationChallengeSender.swift in Sources */,
 				546E89EF1B33015000DD1042 /* ZMTransportPushChannelTests.m in Sources */,


### PR DESCRIPTION
## What's new in this PR?

to allow the data-model to trigger a new request available notification `RequestAvailableNotification.notifyNewRequestsAvailable(nil)` I moved the `RequestAvailableNotification` class from the request-strategy to the transport layer.

## Dependencies

