### PR TITLE
[Fix] Replace custom date encoder/decoder with NSDateFormatter

### DIFF
--- a/Source/TransportEncoding/NSObject+ZMTransportEncoding.m
+++ b/Source/TransportEncoding/NSObject+ZMTransportEncoding.m
@@ -20,68 +20,37 @@
 @import WireSystem;
 
 #import "NSObject+ZMTransportEncoding.h"
-#import <time.h>
-#import <xlocale.h>
 
-
-static char const * const FormatString = "%Y-%m-%dT%H:%M:%S";
-static char const * const RemainderFormatString = ".%03dZ";
-
-static locale_t posixLocale()
-{
-    static locale_t locale;
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        locale = newlocale(LC_ALL_MASK, NULL, NULL);
-    });
-    return locale;
-}
-
-
+static NSDateFormatter* iso8601DateFormatter;
 
 @implementation NSDate (ZMTransportEncoding)
 
-///TODO: review this method for iOS 13 beta, can we retire below 2 methods?
+// NOTE: can be replaced by NSISO8601DateFormatter when we drop support for iOS 10
++ (NSDateFormatter *)ISO8601DateFormatter
+{
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSDateFormatter *dateFormatter = [[NSDateFormatter alloc] init];
+        NSLocale *enUSPOSIXLocale = [NSLocale localeWithLocaleIdentifier:@"en_US_POSIX"];
+        [dateFormatter setLocale:enUSPOSIXLocale];
+        [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation: @"UTC"]];
+        [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"];
+        [dateFormatter setCalendar:[NSCalendar calendarWithIdentifier:NSCalendarIdentifierGregorian]];
+        
+        iso8601DateFormatter = dateFormatter;
+    });
+        
+    return iso8601DateFormatter;
+}
+
 + (instancetype)dateWithTransportString:(NSString *)transportString;
 {
-    struct {
-        struct tm sometime;
-    } s;
-    char const * const dateString = [transportString UTF8String];
-    VerifyReturnNil(dateString != NULL);
-    char const * const remainderString = strptime_l(dateString, FormatString, &s.sometime, posixLocale());
-    if (remainderString == NULL) {
-        return nil;
-    }
-    NSTimeInterval interval = timegm(&s.sometime);
-    int milli = 0;
-    int c = sscanf_l(remainderString, posixLocale(), RemainderFormatString, &milli);
-    if (c == 1) {
-        interval += 0.001 * milli;
-    }
-    if (interval < -100) {
-        return nil;
-    }
-    
-    return [NSDate dateWithTimeIntervalSince1970:interval];
+    return [[self ISO8601DateFormatter] dateFromString:transportString];
 }
 
 - (NSString *)transportString;
 {
-    char buffer[80];
-    
-    struct tm sometime;
-    time_t const t = (time_t) floor([self timeIntervalSince1970]);
-    (void) gmtime_r(&t, &sometime);
-    size_t const c = strftime_l(buffer, sizeof(buffer), FormatString, &sometime, posixLocale());
-    RequireString(c != 0, "Could not create transport string from date");
-    
-    double remainder = [self timeIntervalSince1970] - floor([self timeIntervalSince1970]);
-    long milli = (long) fmax(fmin(round(remainder * 1000.), 999), 0);
-    int const c2 = snprintf_l(buffer + c, sizeof(buffer) - c, posixLocale(), RemainderFormatString, (int) milli);
-    RequireString(c2 != 0, "Could not create transport string from date");
-
-    return [NSString stringWithUTF8String:buffer];
+    return [[NSDate ISO8601DateFormatter] stringFromDate:self];
 }
 
 @end


### PR DESCRIPTION
## What's new in this PR?

### Issues

`[NSDate transportString]` and `[NSDate dateWithTransportString]` are expensive calls, which is bad for event processing performance since it needs to convert many strings into dates.

### Causes

The NSDate encoding/decoding is custom code relying on `strptime_l ` and `sscanf_l` which is not very optimised for speed.

### Solutions
 
Replace the custom encoding/decoding with a `NSDateFormatter` configured to parse ISO8601 dates.

This improves the `EventProcessingPerformanceTests` from  17s to 12s (~ 30% improvement).

## Notes

Since iOS 10 there's also a `ISO8601DateFormatter` but we can't use it since we need the `.withFractionalSeconds` options which was introduced in iOS 11.