### PR TITLE
[Fix] Make the countlyURL optional in the backend environment

### DIFF
--- a/Source/Public/BackendEndpoints.swift
+++ b/Source/Public/BackendEndpoints.swift
@@ -25,7 +25,7 @@ final class BackendEndpoints: NSObject, BackendEndpointsProvider, Codable {
     let teamsURL: URL
     let accountsURL: URL
     let websiteURL: URL
-    let countlyURL: URL
+    let countlyURL: URL?
 
     init(backendURL: URL,
          backendWSURL: URL,
@@ -33,7 +33,7 @@ final class BackendEndpoints: NSObject, BackendEndpointsProvider, Codable {
          teamsURL: URL,
          accountsURL: URL,
          websiteURL: URL,
-         countlyURL: URL) {
+         countlyURL: URL?) {
         self.backendURL = backendURL
         self.backendWSURL = backendWSURL
         self.blackListURL = blackListURL

--- a/Source/Public/BackendEnvironment.swift
+++ b/Source/Public/BackendEnvironment.swift
@@ -141,7 +141,7 @@ extension BackendEnvironment: BackendEnvironmentProvider {
         return endpoints.websiteURL
     }
 
-    public var countlyURL: URL {
+    public var countlyURL: URL? {
         return endpoints.countlyURL
     }
 

--- a/Source/Public/BackendEnvironmentProvider.swift
+++ b/Source/Public/BackendEnvironmentProvider.swift
@@ -43,7 +43,7 @@ import Foundation
     var teamsURL: URL { get }
     var accountsURL: URL { get }
     var websiteURL: URL { get }
-    var countlyURL: URL { get }
+    var countlyURL: URL? { get }
 }
 
 @objc public protocol BackendEnvironmentProvider: BackendTrustProvider, BackendEndpointsProvider {

--- a/Tests/Source/Helpers/MockEnvironment.swift
+++ b/Tests/Source/Helpers/MockEnvironment.swift
@@ -30,6 +30,6 @@ public class MockEnvironment: NSObject, BackendEnvironmentProvider {
     public var teamsURL: URL = URL(string: "http://example.com")!
     public var accountsURL: URL = URL(string: "http://example.com")!
     public var websiteURL: URL = URL(string: "http://example.com")!
-    public var countlyURL: URL = URL(string: "http://example.com")!
+    public var countlyURL: URL? = URL(string: "http://example.com")!
     public var environmentType: EnvironmentTypeProvider = EnvironmentTypeProvider(environmentType: .production)
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

It's not possible to switch to a custom backend.

### Causes

After the introduction of the countlyURL in the `BackendEnvironment` all existing custom backend configurations will fail since they don't have the `countlyURL` defined.

### Solutions

Make the `countlyURL` optional.