### PR TITLE
[Refactor] Inject the app version for the user agent into the transport sessions

### DIFF
--- a/Source/Authentication/ZMAccessTokenHandler.m
+++ b/Source/Authentication/ZMAccessTokenHandler.m
@@ -191,7 +191,6 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
     self.activity = [[BackgroundActivityFactory sharedFactory] startBackgroundActivityWithName:@"Network request: POST /access"];
     NSURL *URL = [NSURL URLWithString:@"/access" relativeToURL:self.baseURL];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:URL];
-    [ZMUserAgent setUserAgentOnRequest:request];
     [request setHTTPMethod:@"POST"];
     [request addValue:[ZMTransportCodec encodedContentType] forHTTPHeaderField:@"Content-Type"];
     [request addValue:[ZMTransportCodec encodedContentType] forHTTPHeaderField:@"Accept"];

--- a/Source/Public/ZMTransportSession.h
+++ b/Source/Public/ZMTransportSession.h
@@ -81,7 +81,8 @@ extern NSString * const ZMTransportSessionNewRequestAvailableNotification;
                       cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
                        reachability:(id<ReachabilityProvider, TearDownCapable>)reachability
                  initialAccessToken:(nullable ZMAccessToken *)initialAccessToken
-         applicationGroupIdentifier:(nullable NSString *)applicationGroupIdentifier;
+         applicationGroupIdentifier:(nullable NSString *)applicationGroupIdentifier
+                 applicationVersion:(nonnull NSString *)applicationVersion;
 
 - (void)tearDown;
 

--- a/Source/Public/ZMURLSession.h
+++ b/Source/Public/ZMURLSession.h
@@ -41,7 +41,8 @@ extern NSString * const ZMURLSessionVoipIdentifier;
                         trustProvider:(id<BackendTrustProvider>)trustProvider
                              delegate:(id<ZMURLSessionDelegate>)delegate
                         delegateQueue:(NSOperationQueue *)queue
-                           identifier:(NSString *)identifier;
+                           identifier:(NSString *)identifier
+                            userAgent:(NSString *)userAgent;
 
 - (void)setTimeoutTimer:(ZMTimer *)timer forTask:(NSURLSessionTask *)task;
 

--- a/Source/Public/ZMUserAgent.h
+++ b/Source/Public/ZMUserAgent.h
@@ -23,9 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ZMUserAgent : NSObject
 
-+ (void)setUserAgentOnRequest:(NSMutableURLRequest *)request;
-+ (NSString *)userAgentValue;
-+ (void)setWireAppVersion:(NSString *)appVersion;
++ (NSString *)userAgentWithAppVersion:(NSString *)appVersion;
 
 @end
 

--- a/Source/Requests/ZMUserAgent.m
+++ b/Source/Requests/ZMUserAgent.m
@@ -21,10 +21,6 @@
 #import <mach-o/dyld.h>
 #import <sys/utsname.h>
 
-static NSString *ZMWireAppVersion = nil;
-static NSString *ZMUserAgentValue = nil;
-
-
 @implementation ZMUserAgent
 
 + (NSString *)deviceName
@@ -40,58 +36,39 @@ static NSString *ZMUserAgentValue = nil;
     }
 }
 
-+ (void)setWireAppVersion:(NSString *)appVersion;
++ (NSString *)userAgentWithAppVersion:(NSString *)appVersion
 {
-    ZMWireAppVersion = [appVersion copy];
-    // invalidate user agent cache
-    ZMUserAgentValue = nil;
-}
-
-+ (void)setUserAgentOnRequest:(NSMutableURLRequest *)request;
-{
-    [request setValue:[self userAgentValue] forHTTPHeaderField:@"User-Agent"];
-}
-
-
-+ (NSString *)userAgentValue;
-{
-    if (ZMUserAgentValue == nil) {
-        // This is covered by Section 5.5.3 of HTTP/1.1 Semantics and Content
-        // <http://tools.ietf.org/html/rfc7231#section-5.5.3>
-        //
-        // Basically:
-        //
-        //     ProductName1/Version1 (Comments1) ProductName2/Version2 (Comments2) ...
-        
-        NSMutableString *agent = [NSMutableString string];
-        
-        // app version:
-        if(ZMWireAppVersion != nil) {
-            [agent appendFormat:@"wire/%@ ", ZMWireAppVersion];
-        }
-        
-        // zmessaging:
-        [agent appendFormat:@"zmessaging/%@ ", [[[NSBundle bundleForClass:NSClassFromString(@"ZMUserSession")] infoDictionary] objectForKey:@"CFBundleShortVersionString"]];
-        [agent appendFormat:@"ztransport/%@ ", [[[NSBundle bundleForClass:self] infoDictionary] objectForKey:@"CFBundleVersion"]];
-        
-        // CFNetwork (which we use for all our networking)
-        int32_t version = NSVersionOfRunTimeLibrary("CFNetwork");
-        if (version != -1) {
-            [agent appendString:@"CFNetwork/"];
-            uint16_t const a = ((uint32_t) version) >> 16;
-            uint8_t const b = (((uint32_t) version) >> 8) & 0xf;
-            uint8_t const c = ((uint32_t) version) & 0xf;
-            [agent appendFormat:@"%u.%u.%u", a, b, c];
-        }
-        
-        // device and locale
-        [agent appendFormat:@" (iOS; %@)", [NSLocale currentLocale].localeIdentifier];
-        
-        
-        ZMUserAgentValue = [agent copy];
+    // This is covered by Section 5.5.3 of HTTP/1.1 Semantics and Content
+    // <http://tools.ietf.org/html/rfc7231#section-5.5.3>
+    //
+    // Basically:
+    //
+    //     ProductName1/Version1 (Comments1) ProductName2/Version2 (Comments2) ...
+    
+    NSMutableString *agent = [NSMutableString string];
+    
+    // app version:
+    [agent appendFormat:@"wire/%@ ", appVersion];
+    
+    // zmessaging:
+    [agent appendFormat:@"zmessaging/%@ ", [[[NSBundle bundleForClass:NSClassFromString(@"ZMUserSession")] infoDictionary] objectForKey:@"CFBundleShortVersionString"]];
+    [agent appendFormat:@"ztransport/%@ ", [[[NSBundle bundleForClass:ZMUserAgent.self] infoDictionary] objectForKey:@"CFBundleVersion"]];
+    
+    // CFNetwork (which we use for all our networking)
+    int32_t version = NSVersionOfRunTimeLibrary("CFNetwork");
+    if (version != -1) {
+        [agent appendString:@"CFNetwork/"];
+        uint16_t const a = ((uint32_t) version) >> 16;
+        uint8_t const b = (((uint32_t) version) >> 8) & 0xf;
+        uint8_t const c = ((uint32_t) version) & 0xf;
+        [agent appendFormat:@"%u.%u.%u", a, b, c];
     }
-    return ZMUserAgentValue;
+    
+    // device and locale
+    [agent appendFormat:@" (iOS; %@)", [NSLocale currentLocale].localeIdentifier];
+    
+    
+    return [agent copy];
 }
-
 
 @end

--- a/Source/TransportSession/ZMTransportSession+internal.h
+++ b/Source/TransportSession/ZMTransportSession+internal.h
@@ -34,14 +34,15 @@
 @interface ZMTransportSession ()
 
 - (instancetype)initWithURLSessionsDirectory:(id<URLSessionsDirectory, TearDownCapable>)directory
-                        requestScheduler:(ZMTransportRequestScheduler *)requestScheduler
-                            reachability:(id<ReachabilityProvider, TearDownCapable>)reachability
-                                   queue:(NSOperationQueue *)queue
-                                   group:(ZMSDispatchGroup *)group
-                             environment:(id<BackendEnvironmentProvider>)environment
-                        pushChannelClass:(Class)pushChannelClass
-                           cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
-                      initialAccessToken:(ZMAccessToken *)initialAccessToken NS_DESIGNATED_INITIALIZER;
+                            requestScheduler:(ZMTransportRequestScheduler *)requestScheduler
+                                reachability:(id<ReachabilityProvider, TearDownCapable>)reachability
+                                       queue:(NSOperationQueue *)queue
+                                       group:(ZMSDispatchGroup *)group
+                                 environment:(id<BackendEnvironmentProvider>)environment
+                            pushChannelClass:(Class)pushChannelClass
+                               cookieStorage:(ZMPersistentCookieStorage *)cookieStorage
+                          initialAccessToken:(ZMAccessToken *)initialAccessToken
+                                   userAgent:(NSString *)userAgent NS_DESIGNATED_INITIALIZER;
 
 - (NSURLSessionTask *)suspendedTaskForRequest:(ZMTransportRequest *)request onSession:(ZMURLSession *)session;
 

--- a/Source/URLSession/ZMURLSession.m
+++ b/Source/URLSession/ZMURLSession.m
@@ -81,14 +81,19 @@ ZM_EMPTY_ASSERTING_INIT();
     return self;
 }
 
-- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration trustProvider:(id<BackendTrustProvider>)trustProvider
- delegate:(id<ZMURLSessionDelegate>)delegate delegateQueue:(NSOperationQueue *)queue identifier:(NSString *)identifier
+- (instancetype)initWithConfiguration:(NSURLSessionConfiguration *)configuration
+                        trustProvider:(id<BackendTrustProvider>)trustProvider
+                             delegate:(id<ZMURLSessionDelegate>)delegate
+                        delegateQueue:(NSOperationQueue *)queue
+                           identifier:(NSString *)identifier
+                            userAgent:(NSString *)userAgent
 {
     Require(configuration != nil);
     Require(delegate != nil);
     Require(queue != nil);
     self = [self initWithDelegate:delegate identifier:identifier];
     if(self) {
+        configuration.HTTPAdditionalHeaders = @{ @"User-Agent": userAgent };
         self.backingSession = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:queue];
         self.backingSession.sessionDescription = identifier;
         self.trustProvider = trustProvider;

--- a/Tests/Source/Helpers/ZMMockURLSession.swift
+++ b/Tests/Source/Helpers/ZMMockURLSession.swift
@@ -23,12 +23,12 @@ import WireTransport
     @objc var cancellationHandler: (() -> Void)? = nil
 
     @objc static func createMockSession() -> ZMMockURLSession {
-        return ZMMockURLSession(configuration: .ephemeral, trustProvider: MockEnvironment(), delegate: ZMMockURLSessionDelegate(), delegateQueue: OperationQueue(), identifier: "ZMMockURLSession")
+        return ZMMockURLSession(configuration: .ephemeral, trustProvider: MockEnvironment(), delegate: ZMMockURLSessionDelegate(), delegateQueue: OperationQueue(), identifier: "ZMMockURLSession", userAgent: "Test UserAgent")
     }
 
     @objc(createMockSessionWithDelegate:)
     static func createMockSession(delegate: ZMURLSessionDelegate) -> ZMMockURLSession {
-        return ZMMockURLSession(configuration: .ephemeral, trustProvider: MockEnvironment(), delegate: delegate, delegateQueue: OperationQueue(), identifier: "ZMMockURLSession")
+        return ZMMockURLSession(configuration: .ephemeral, trustProvider: MockEnvironment(), delegate: delegate, delegateQueue: OperationQueue(), identifier: "ZMMockURLSession", userAgent: "Test UserAgent")
     }
 
     override func cancelAllTasks(completionHandler handler: @escaping () -> Void) {

--- a/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -95,7 +95,8 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         let environment = BackendEnvironment(title: name, environmentType: .production, endpoints: endpoints, certificateTrust: trust)
         sut = UnauthenticatedTransportSession(environment: environment,
                                               urlSession: sessionMock,
-                                              reachability: MockReachability())
+                                              reachability: MockReachability(),
+                                              applicationVersion: "1.0")
     }
 
     override func tearDown() {

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -335,6 +335,7 @@ static XCTestCase *currentTestCase;
 @property (nonatomic) FakeReachability *reachability;
 @property (nonatomic) MockBackgroundActivityManager *activityManager;
 @property (nonatomic) MockEnvironment *environment;
+@property (nonatomic) NSString *userAgent;
 
 @end
 
@@ -378,6 +379,7 @@ static XCTestCase *currentTestCase;
     currentTestCase = self;
     [super setUp];
 
+    self.userAgent = @"ZMTransportSessionTests User Agent";
     self.scheduler = [[FakeTransportRequestScheduler alloc] init];
     self.userIdentifier = NSUUID.createUUID;
     self.dataTask = [OCMockObject mockForClass:FakeDataTask.class];
@@ -412,7 +414,8 @@ static XCTestCase *currentTestCase;
                 environment:self.environment
                 pushChannelClass:FakePushChannel.class
                 cookieStorage:self.cookieStorage
-                initialAccessToken:nil];
+                initialAccessToken:nil
+                userAgent:self.userAgent];
 
     __weak id weakSelf = self;
     [self.sut setAccessTokenRenewalFailureHandler:^(ZMTransportResponse *response) {
@@ -552,7 +555,8 @@ static XCTestCase *currentTestCase;
                 environment:self.environment
                 pushChannelClass:nil
                 cookieStorage:self.cookieStorage
-                initialAccessToken:nil];
+                initialAccessToken:nil
+                userAgent:self.userAgent];
     
     self.sut.accessToken = self.validAccessToken;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
@@ -770,7 +774,8 @@ static XCTestCase *currentTestCase;
                                environment:self.environment
                                pushChannelClass:nil
                                cookieStorage:self.cookieStorage
-                               initialAccessToken:nil];
+                               initialAccessToken:nil
+                               userAgent:self.userAgent];
     
     sut.accessToken = self.validAccessToken;
     id<ZMTransportData> payload = @{@"numbers": @[@4, @8, @15, @16, @23, @42]};
@@ -1640,7 +1645,7 @@ static XCTestCase *currentTestCase;
 {
     XCTAssertNotNil(currentFakePushChannel);
     XCTAssertEqualObjects(currentFakePushChannel.URL, self.environment.backendWSURL);
-    XCTAssertEqualObjects(currentFakePushChannel.userAgentString, [ZMUserAgent userAgentValue]);
+    XCTAssertEqualObjects(currentFakePushChannel.userAgentString, self.userAgent);
     XCTAssertEqualObjects(currentFakePushChannel.scheduler, self.scheduler);
 }
 
@@ -1855,7 +1860,7 @@ static XCTestCase *currentTestCase;
         configuration = NSURLSessionConfiguration.defaultSessionConfiguration;
     }
     
-    ZMURLSession *session = [[ZMURLSession alloc] initWithConfiguration:configuration trustProvider:self.environment delegate:delegate delegateQueue:NSOperationQueue.mainQueue identifier:backgroundSession ? ZMURLSessionBackgroundIdentifier : @"default-session"];
+    ZMURLSession *session = [[ZMURLSession alloc] initWithConfiguration:configuration trustProvider:self.environment delegate:delegate delegateQueue:NSOperationQueue.mainQueue identifier:backgroundSession ? ZMURLSessionBackgroundIdentifier : @"default-session" userAgent:@"TestSession"];
     if (backgroundSession) {
         XCTAssertTrue(session.isBackgroundSession);
     }
@@ -2320,7 +2325,7 @@ static XCTestCase *currentTestCase;
     
     id mockDelegate = [OCMockObject niceMockForProtocol:@protocol(ZMURLSessionDelegate)];
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:self.name];
-    ZMURLSession *session = [[ZMURLSession alloc] initWithConfiguration:configuration trustProvider:self.environment delegate:mockDelegate delegateQueue:self.queue identifier:@"test-session"];
+    ZMURLSession *session = [[ZMURLSession alloc] initWithConfiguration:configuration trustProvider:self.environment delegate:mockDelegate delegateQueue:self.queue identifier:@"test-session" userAgent:@"TestSession"];
     XCTestExpectation *expectation = [self expectationWithDescription:@"It should call the completion handler on the main thread"];
     
     // when

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.swift
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.swift
@@ -81,7 +81,7 @@ class ZMTransportSessionTests_Initialization: ZMTBaseTest {
         cookieStorage = ZMPersistentCookieStorage(forServerName: serverName, userIdentifier: userIdentifier)
         reachability = FakeReachability()
         environment = MockEnvironment()
-        sut = ZMTransportSession(environment: environment, cookieStorage: cookieStorage, reachability: reachability, initialAccessToken: nil, applicationGroupIdentifier: containerIdentifier)
+        sut = ZMTransportSession(environment: environment, cookieStorage: cookieStorage, reachability: reachability, initialAccessToken: nil, applicationGroupIdentifier: containerIdentifier, applicationVersion: "1.0")
     }
     
     override func tearDown() {

--- a/Tests/Source/URLSession/ZMURLSessionTests.m
+++ b/Tests/Source/URLSession/ZMURLSessionTests.m
@@ -78,7 +78,8 @@ static NSString * const DataKey = @"data";
                                                   trustProvider:self.trustProvider
                                                        delegate:self
                                                   delegateQueue:self.queue
-                                                     identifier:@"test-session"];
+                                                     identifier:@"test-session"
+                                                      userAgent:@"TestSession"];
 
     self.URLRequestA = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.example.com/"]];
     self.URLRequestB = [NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.example.com/"]];
@@ -160,6 +161,11 @@ static NSString * const DataKey = @"data";
     XCTAssertEqual(self.completedTasks.count, 1u);
     NSDictionary *d = self.completedTasks.firstObject;
     XCTAssertEqual(d[RequestKey], request);
+}
+
+- (void)testThatUserAgentIsAddedToAdditionalHeaders
+{
+    XCTAssertEqualObjects(self.sut.configuration.HTTPAdditionalHeaders[@"User-Agent"], @"TestSession");
 }
 
 - (void)testThatItCancelsTheTimerWhenTheTaskCompletes;
@@ -528,7 +534,7 @@ willPerformHTTPRedirection:response
 
 - (void)setupMockBackgroundSession
 {    
-    self.sut = (id) [[ZMURLSession alloc] initWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration] trustProvider:self.trustProvider delegate:self delegateQueue:self.queue identifier:ZMURLSessionBackgroundIdentifier];
+    self.sut = (id) [[ZMURLSession alloc] initWithConfiguration:[NSURLSessionConfiguration ephemeralSessionConfiguration] trustProvider:self.trustProvider delegate:self delegateQueue:self.queue identifier:ZMURLSessionBackgroundIdentifier userAgent:@"TestSession"];
     self.sut.backingSession = [OCMockObject niceMockForClass:NSURLSession.class];
     
     [(NSURLSession *)[[(id)self.sut.backingSession stub] andReturn:[NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:@"test-session"]] configuration];
@@ -543,7 +549,7 @@ willPerformHTTPRedirection:response
     WaitForAllGroupsToBeEmpty(0.5);
     [self spinMainQueueWithTimeout:0.1];
     
-    self.sut = (id) [[ZMURLSession alloc] initWithConfiguration:configuration trustProvider:self.trustProvider delegate:self delegateQueue:self.queue identifier:ZMURLSessionBackgroundIdentifier];
+    self.sut = (id) [[ZMURLSession alloc] initWithConfiguration:configuration trustProvider:self.trustProvider delegate:self delegateQueue:self.queue identifier:ZMURLSessionBackgroundIdentifier userAgent:@"TestSession"];
     WaitForAllGroupsToBeEmpty(0.5);
     [self spinMainQueueWithTimeout:0.1];
     
@@ -680,7 +686,7 @@ willPerformHTTPRedirection:response
     [self spinMainQueueWithTimeout:0.1];
 
     NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration backgroundSessionConfigurationWithIdentifier:@"test-session"];
-    self.sut = (id) [[ZMURLSession alloc] initWithConfiguration:configuration trustProvider:self.trustProvider delegate:self delegateQueue:self.queue identifier:ZMURLSessionBackgroundIdentifier];
+    self.sut = (id) [[ZMURLSession alloc] initWithConfiguration:configuration trustProvider:self.trustProvider delegate:self delegateQueue:self.queue identifier:ZMURLSessionBackgroundIdentifier userAgent:@"TestSession"];
     WaitForAllGroupsToBeEmpty(0.5);
     [self spinMainQueueWithTimeout:0.1];
 


### PR DESCRIPTION
## What's new in this PR?

### Problem
We set custom User-Agent on our requests from the transport session. This user agent includes the version number of the app, which is currently set by calling the static method:

```
[ZMUserAgent setWireAppVersion:]
```

Static method calls like this are hard to write tests for without a mocking framework which doesn't work in Swift.

### Refactoring

- Set the user agent on the `URLSessionConfiguration` instead of manually setting on every request we schedule.
- Create the user agent string in the `ZMTransportSession` init using the already existing `appVersion` parameter
- Create the user agent string in the `UnauthenticatedSession` init by adding an `appVersion` parameter