### PR TITLE
[Fix] Stop adding authorization headers to redirects since it interferes with asset fetching

### DIFF
--- a/Source/URLSession/ZMURLSession.m
+++ b/Source/URLSession/ZMURLSession.m
@@ -320,24 +320,14 @@ willPerformHTTPRedirection:(NSHTTPURLResponse * __unused)response
 {
     ZMTransportRequest *orginalRequest = [self requestForTask:task];
     if (orginalRequest.doesNotFollowRedirects) {
-        if(completionHandler) {
+        if (completionHandler) {
             completionHandler(nil);
         }
         return;
     }
-    NSURLRequest *finalRequest = request;
-    NSString *AuthenticationHeaderName = @"Authorization";
     
-    // add authentication token
-    NSString *authToken = task.originalRequest.allHTTPHeaderFields[AuthenticationHeaderName];
-    if(authToken != nil) {
-        NSMutableURLRequest *mutableRequest = [request mutableCopy];
-        [mutableRequest setValue:authToken forHTTPHeaderField:AuthenticationHeaderName];
-        finalRequest = mutableRequest;
-    }
-    
-    if(completionHandler) {
-        completionHandler(finalRequest);
+    if (completionHandler) {
+        completionHandler(request);
     }
 }
 

--- a/Tests/Source/URLSession/ZMURLSessionTests.m
+++ b/Tests/Source/URLSession/ZMURLSessionTests.m
@@ -347,40 +347,6 @@ static NSString * const DataKey = @"data";
     XCTAssertEqual(d[TaskKey], self.taskA);
 }
 
-- (void)testThatItAddsAuthenticationTokenToRedirect
-{
-    // given
-    NSString *initialURL = @"https://example.com/initial";
-    NSString *finalURL = @"https://example.com/final";
-    NSString *tokenValue = @"abc123456";
-    NSString *tokenKey = @"Authorization";
-    
-    NSMutableURLRequest *originalRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:initialURL]];
-    [originalRequest setValue:tokenValue forHTTPHeaderField:tokenKey];
-    NSURLSessionDataTask *originalTask = [self.sut.backingSession dataTaskWithRequest:originalRequest];
-    
-    NSURLRequest *newRequest = [NSMutableURLRequest requestWithURL:[NSURL URLWithString:finalURL]];
-    
-    XCTestExpectation *completionHandlerCalled = [self expectationWithDescription:@"Completion handler invoked"];
-    
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"foo"] statusCode:302 HTTPVersion:@"1.1" headerFields:@{}];
-    
-    // when
-    [self.sut URLSession:self.sut.backingSession
-                    task:originalTask
-willPerformHTTPRedirection:response
-              newRequest:newRequest
-       completionHandler:^(NSURLRequest * _Nullable req) {
-        XCTAssertEqualObjects(req.URL, [NSURL URLWithString:finalURL]);
-        XCTAssertEqualObjects(req.allHTTPHeaderFields[tokenKey], tokenValue);
-        
-        [completionHandlerCalled fulfill];
-    }];
-    
-    // then
-    XCTAssertTrue([self waitForCustomExpectationsWithTimeout:0]);
-}
-
 - (void)testThatItDoesNotFollowRedirectsIfSpecified
 {
     // given


### PR DESCRIPTION
## What's new in this PR?

### Issues

Assets fetching fails with status 400 when running against a on premise installation of Wire.

```
[Network] <---- Response to GET /assets/v3/3-1-a8c0d976-61a6-49f2-9ef7-2d931d813b9f (status 400): <ZMTransportResponse: 0x600002989ae0> 400 {
    "Accept-Ranges" = bytes;
    "Content-Length" = 267;
    "Content-Type" = "application/xml";
    Date = "Thu, 14 Jan 2021 14:00:45 GMT";
    Server = "nginx/1.17.8";
    "Strict-Transport-Security" = "max-age=15724800; includeSubDomains";
    Vary = Origin;
} (null)
```

### Causes

We modify all redirects by adding authorisation headers. Redirects are mostly used by the backend when fetching assets where they will redirect the client to an CDN, this redirect already includes all the necessary authorisation and adding an additional one causes the on premise setup to reject the request.

### Solutions

Remove the logic for adding authorisation headers to redirects. It was most likely added to support one of the older now deprecated asset types (1 or 2).
