### PR TITLE
[Fix] Request loop falsely being detected when receiving messages

### DIFF
--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -183,7 +183,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
         self.acceptedResponseMediaTypes = ZMTransportAcceptTransportData;
         self.shouldCompress = shouldCompress;
         self.debugInformation = [NSMutableArray array];
-        self.contentDebugInformationHash = 0;
+        self.contentDebugInformationHash = payload.hash;
     }
     return self;
 }
@@ -262,6 +262,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
         self.acceptedResponseMediaTypes = ZMTransportAcceptTransportData;
         self.shouldCompress = shouldCompress;
         self.debugInformation = [NSMutableArray array];
+        self.contentDebugInformationHash = data.hash;
     }
     return self;
 }


### PR DESCRIPTION
## What's new in this PR?

### Issues

QA is triggering the request loop detection alert when receiving many messages in a short period of time.

### Causes

The request loop detection is based on the HTTP request path and a hash based on the debug information of the request. This debug information is not set for every request though and there's no guarantee that it is uniquely identifying the request payload. 

For example when sending delivery receipts the debug information attached to the request is: "Confirmation Message". This doesn't include any IDs thus it will potentially trigger a request loop alert.

### Solutions

Compute the "content" has either on the complete binary data or the payload dictionary.

## Notes

I would like to change the of `contentDebugInformationHash` to `contentHash` and make it private, but since that is a API breaking change I would do it in a separate PR.