### PR TITLE
Bump components due to major a release

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "wireapp/wire-ios-utilities" ~> 38.0.0
+github "wireapp/wire-ios-utilities" ~> 39.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,4 +1,4 @@
 github "wireapp/ocmock" "v3.4.3"
 github "wireapp/wire-ios-system" "31.1.0"
 github "wireapp/wire-ios-testing" "22.0.0"
-github "wireapp/wire-ios-utilities" "38.0.0"
+github "wireapp/wire-ios-utilities" "39.0.0"


### PR DESCRIPTION
## What's new in this PR?

Bump components due to a major release of `wire-ios-utilities`