### PR TITLE
[Fix] Websocket not connecting after the access token has expired

### DIFF
--- a/Source/Public/ZMTransportRequestScheduler.h
+++ b/Source/Public/ZMTransportRequestScheduler.h
@@ -21,6 +21,7 @@
 #import <WireSystem/WireSystem.h>
 #import <WireUtilities/WireUtilities.h>
 #import <WireTransport/ZMReachability.h>
+#import <WireTransport/ZMTransportRequest.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -85,6 +86,21 @@ extern NSInteger const ZMTransportRequestSchedulerRequestCountUnlimited;
 
 @end
 
+/// This protocol allows the ZMTransportSession to handle both ZMTransportRequest and ZMPushChannel as scheduled items.
+@protocol ZMTransportRequestSchedulerItemAsRequest <NSObject>
+
+/// If the receiver is a transport request, returns @c self, @c nil otherwise
+@property (nonatomic, readonly) ZMTransportRequest *transportRequest;
+/// If the receiver is a request to open the push channel
+@property (nonatomic, readonly) BOOL isPushChannelRequest;
+
+@end
+
+@interface ZMOpenPushChannelRequest : NSObject <ZMTransportRequestSchedulerItem, ZMTransportRequestSchedulerItemAsRequest>
+@end
+
+@interface ZMTransportRequest (Scheduler) <ZMTransportRequestSchedulerItem, ZMTransportRequestSchedulerItemAsRequest>
+@end
 
 
 @protocol ZMTransportRequestSchedulerSession <NSObject>

--- a/Source/TransportSession/ZMTransportSession+internal.h
+++ b/Source/TransportSession/ZMTransportSession+internal.h
@@ -70,27 +70,3 @@
 - (void)updateNetworkStatusFromDidReadDataFromNetwork;
 
 @end
-
-
-
-/// This protocol allows the ZMTransportSession to handle both ZMTransportRequest and ZMPushChannel as scheduled items.
-@protocol ZMTransportRequestSchedulerItemAsRequest <NSObject>
-
-/// If the receiver is a transport request, returns @c self, @c nil otherwise
-@property (nonatomic, readonly) ZMTransportRequest *transportRequest;
-/// If the receiver is a request to open the push channel
-@property (nonatomic, readonly) BOOL isPushChannelRequest;
-
-@end
-
-
-
-@interface ZMOpenPushChannelRequest : NSObject <ZMTransportRequestSchedulerItem, ZMTransportRequestSchedulerItemAsRequest>
-@end
-
-
-
-@interface ZMTransportRequest (Scheduler) <ZMTransportRequestSchedulerItem, ZMTransportRequestSchedulerItemAsRequest>
-@end
-
-

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -560,9 +560,8 @@ static NSInteger const DefaultMaximumRequests = 6;
 - (void)handlerDidReceiveAccessToken:(ZMAccessTokenHandler *)handler
 {
     NOT_USED(handler);
-    [self.requestScheduler sessionDidReceiveAccessToken:self];
-    
     self.transportPushChannel.accessToken = self.accessToken;
+    [self.requestScheduler sessionDidReceiveAccessToken:self];
 }
 
 - (void)handlerDidClearAccessToken:(ZMAccessTokenHandler *)handler


### PR DESCRIPTION
## What's new in this PR?

### Issues

Websocket sometimes doesn't connect after returning from the background.

### Causes

If the access token expired while the app was is in the the background the websocket task would never finish because it used and invalid access token.

### Solutions

Open the websocket using the scheduler like we do for the legacy websocket implementation. The scheduler will make sure that we have a valid access token.