### PR TITLE
[Fix] Sometimes all requests never finish and timeout

### DIFF
--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -111,7 +111,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     // RFC 2616 recommends no more than 2 connections per host when using pipelining.
     // https://tools.ietf.org/html/rfc2616
     configuration.HTTPShouldUsePipelining = YES;
-    configuration.HTTPMaximumConnectionsPerHost = 1;
+    configuration.HTTPMaximumConnectionsPerHost = 2;
     
     configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
     

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -110,7 +110,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     // Turn on HTTP pipelining
     // RFC 2616 recommends no more than 2 connections per host when using pipelining.
     // https://tools.ietf.org/html/rfc2616
-    configuration.HTTPShouldUsePipelining = YES;
+    configuration.HTTPShouldUsePipelining = NO;
     configuration.HTTPMaximumConnectionsPerHost = 2;
     
     configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -111,7 +111,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     // RFC 2616 recommends no more than 2 connections per host when using pipelining.
     // https://tools.ietf.org/html/rfc2616
     configuration.HTTPShouldUsePipelining = NO;
-    configuration.HTTPMaximumConnectionsPerHost = 2;
+    configuration.HTTPMaximumConnectionsPerHost = 4;
     
     configuration.TLSMinimumSupportedProtocol = kTLSProtocol12;
     


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes all scheduled requests starts to timeout. The issue usually revolves it self after moving the the app into the background/foreground.

```
<ZMURLSession 0x28163b520> URLSession:task:didCompleteWithError: -> https://prod-nginz-https.wire.com/notifications?size=500&since=ca30c45a-c934-11eb-8005-22000ac389f3&client=67d81a150c0b3f6b (null), error: Error Domain=NSURLErrorDomain Code=-1001 "The request timed out." UserInfo={_kCFStreamErrorCodeKey=-2102, NSUnderlyingError=0x283b4f000 {Error Domain=kCFErrorDomainCFNetwork Code=-1001 "(null)" UserInfo={_kCFStreamErrorCodeKey=-2102, _kCFStreamErrorDomainKey=4}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <E4962FC1-1A79-44F4-962E-2F625411CC83>.<196>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <E4962FC1-1A79-44F4-962E-2F625411CC83>.<196>"
), NSLocalizedDescription=The request timed out., NSErrorFailingURLStringKey=https://prod-nginz-https.wire.com/notifications?size=500&since=ca30c45a-c934-11eb-8005-22000ac389f3&client=67d81a150c0b3f6b, NSErrorFailingURLKey=https://prod-nginz-https.wire.com/notifications?size=500&since=ca30c45a-c934-11eb-8005-22000ac389f3&client=67d81a150c0b3f6b, _kCFStreamErrorDomainKey=4}
```

### Causes

It's still unknown what causes this issue but it started to happen a lot more frequently after we started to use the NSURLSession websocket implementation.

### Solutions

As a potential experiment I'd like to disable HTTP pipelining and increase the `HTTPMaximumConnectionsPerHost` to 4 which is the system default on iOS.