### PR TITLE
[Fix] Sometimes all requests never finish and timeout (2nd attempt)

### DIFF
--- a/Source/PushChannel/NativePushChannel.swift
+++ b/Source/PushChannel/NativePushChannel.swift
@@ -25,7 +25,7 @@ class NativePushChannel: NSObject, PushChannelType {
     var clientID: String? {
         didSet {
             Logging.pushChannel.debug("Setting client ID")
-            scheduleOpenInternal()
+            scheduleOpen()
         }
     }
     
@@ -38,7 +38,7 @@ class NativePushChannel: NSObject, PushChannelType {
     var keepOpen: Bool = false {
         didSet {
             if keepOpen {
-                scheduleOpenInternal()
+                scheduleOpen()
             } else {
                 self.close()
             }
@@ -94,7 +94,7 @@ class NativePushChannel: NSObject, PushChannelType {
         if consumer == nil {
             close()
         } else {
-            scheduleOpenInternal()
+            scheduleOpen()
         }
     }
 
@@ -115,13 +115,13 @@ class NativePushChannel: NSObject, PushChannelType {
         websocketTask?.resume()
     }
 
-    func scheduleOpenInternal() {
-        scheduler.performGroupedBlock {
-            self.scheduleOpen()
+    func scheduleOpen() {
+        scheduler.performGroupedBlock { [weak self] in
+            self?.scheduleOpenInternal()
         }
     }
 
-    func scheduleOpen() {
+    private func scheduleOpenInternal() {
         guard canOpenConnection else {
             Logging.pushChannel.debug("Conditions for scheduling opening not fulfilled, waiting...")
             return

--- a/Source/PushChannel/NativePushChannel.swift
+++ b/Source/PushChannel/NativePushChannel.swift
@@ -25,7 +25,7 @@ class NativePushChannel: NSObject, PushChannelType {
     var clientID: String? {
         didSet {
             Logging.pushChannel.debug("Setting client ID")
-            scheduleOpen()
+            scheduleOpenInternal()
         }
     }
     
@@ -38,10 +38,11 @@ class NativePushChannel: NSObject, PushChannelType {
     var keepOpen: Bool = false {
         didSet {
             if keepOpen {
-                scheduleOpen()
+                scheduleOpenInternal()
             } else {
-                close()
+                self.close()
             }
+
         }
     }
 
@@ -55,24 +56,28 @@ class NativePushChannel: NSObject, PushChannelType {
     var websocketTask: URLSessionWebSocketTask?
     weak var consumer: ZMPushChannelConsumer?
     var consumerQueue: ZMSGroupQueue?
-    var pingTimer: Timer?
+    var workQueue: OperationQueue
+    var pingTimer: ZMTimer?
 
     required init(scheduler: ZMTransportRequestScheduler,
                   userAgentString: String,
-                  environment: BackendEnvironmentProvider) {
+                  environment: BackendEnvironmentProvider,
+                  queue: OperationQueue) {
         self.environment = environment
         self.scheduler = scheduler
+        self.workQueue = queue
 
         super.init()
-
-        self.session = URLSession(configuration: .ephemeral, delegate: self, delegateQueue: .main)
+        self.session = URLSession(configuration: .ephemeral, delegate: self, delegateQueue: queue)
     }
 
     func close() {
         Logging.pushChannel.debug("Push channel was closed")
 
-        websocketTask?.cancel()
-        onClose()
+        scheduler.performGroupedBlock { [weak self] in
+            self?.websocketTask?.cancel()
+            self?.onClose()
+        }
     }
 
     func reachabilityDidChange(_ reachability: ReachabilityProvider) {
@@ -89,7 +94,7 @@ class NativePushChannel: NSObject, PushChannelType {
         if consumer == nil {
             close()
         } else {
-            scheduleOpen()
+            scheduleOpenInternal()
         }
     }
 
@@ -108,6 +113,12 @@ class NativePushChannel: NSObject, PushChannelType {
 
         websocketTask = session?.webSocketTask(with: connectionRequest)
         websocketTask?.resume()
+    }
+
+    func scheduleOpenInternal() {
+        scheduler.performGroupedBlock {
+            self.scheduleOpen()
+        }
     }
 
     func scheduleOpen() {
@@ -133,6 +144,7 @@ class NativePushChannel: NSObject, PushChannelType {
             switch result {
             case.failure(let error):
                 Logging.pushChannel.debug("Failed to receive message \(error)")
+                self?.onClose()
             case .success(let message):
                 guard
                     case .data(let data) = message,
@@ -167,22 +179,34 @@ class NativePushChannel: NSObject, PushChannelType {
     }
 
     private func stopPingTimer() {
-        pingTimer?.invalidate()
+        pingTimer?.cancel()
         pingTimer = nil
     }
 
-    private func startPingTimer() {
-        let timer = Timer(timeInterval: 30, repeats: true) { [weak self] (_) in
-            Logging.pushChannel.debug("Sending ping")
-            self?.websocketTask?.sendPing(pongReceiveHandler: { error in
-                if let error = error {
-                    Logging.pushChannel.debug("Failed to send ping: \(error)")
-                }
-            })
-        }
+    private func schedulePingTimer() {
+        stopPingTimer()
+        startPingTimer()
+    }
 
-        self.pingTimer = timer
-        RunLoop.main.add(timer, forMode: .default)
+    private func startPingTimer() {
+        let timer = ZMTimer(target: self, operationQueue: workQueue)
+        timer?.fire(afterTimeInterval: 30)
+        pingTimer = timer
+    }
+
+}
+
+@available(iOSApplicationExtension 13.0, iOS 13.0, *)
+extension NativePushChannel: ZMTimerClient {
+
+    func timerDidFire(_ timer: ZMTimer!) {
+        Logging.pushChannel.debug("Sending ping")
+        websocketTask?.sendPing(pongReceiveHandler: { error in
+            if let error = error {
+                Logging.pushChannel.debug("Failed to send ping: \(error)")
+            }
+        })
+        schedulePingTimer()
     }
 
 }

--- a/Source/PushChannel/ZMPushChannelType.h
+++ b/Source/PushChannel/ZMPushChannelType.h
@@ -29,7 +29,8 @@ NS_SWIFT_NAME(PushChannelType)
 
 - (instancetype _Nonnull )initWithScheduler:(ZMTransportRequestScheduler * _Nonnull)scheduler
                             userAgentString:(NSString * _Nonnull)userAgentString
-                                environment:(id <BackendEnvironmentProvider> _Nonnull)environment;
+                                environment:(id <BackendEnvironmentProvider> _Nonnull)environment
+                                      queue:(NSOperationQueue * _Nonnull)queue;
 
 /// Set the consumer of push channel messsages.
 ///

--- a/Source/PushChannel/ZMTransportPushChannel.h
+++ b/Source/PushChannel/ZMTransportPushChannel.h
@@ -36,8 +36,9 @@
 @property (nonatomic, weak, nullable) id <ZMNetworkStateDelegate> networkStateDelegate;
 
 - (instancetype _Nonnull )initWithScheduler:(ZMTransportRequestScheduler * _Nonnull)scheduler
-                  userAgentString:(NSString * _Nonnull)userAgentString
-                      environment:(id <BackendEnvironmentProvider> _Nonnull)environment;
+                            userAgentString:(NSString * _Nonnull)userAgentString
+                                environment:(id <BackendEnvironmentProvider> _Nonnull)environment
+                                      queue:(NSOperationQueue * _Nonnull)queue;
 - (instancetype _Nonnull )initWithScheduler:(ZMTransportRequestScheduler * _Nonnull)scheduler
                   userAgentString:(NSString * _Nonnull)userAgentString
                       environment:(id <BackendEnvironmentProvider> _Nonnull)environment

--- a/Source/PushChannel/ZMTransportPushChannel.m
+++ b/Source/PushChannel/ZMTransportPushChannel.m
@@ -89,7 +89,8 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_PUSHCHANNEL;
 
 ZM_EMPTY_ASSERTING_INIT();
 
-- (instancetype)initWithScheduler:(ZMTransportRequestScheduler *)scheduler userAgentString:(NSString *)userAgentString environment:(id <BackendEnvironmentProvider>)environment;
+- (instancetype)initWithScheduler:(ZMTransportRequestScheduler *)scheduler userAgentString:(NSString *)userAgentString environment:(id <BackendEnvironmentProvider>)environment
+                            queue:(NSOperationQueue * _Nonnull)queue;
 {
     return [self initWithScheduler:scheduler userAgentString:userAgentString environment:environment pushChannelClass:nil];
 }

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -270,7 +270,8 @@ static NSInteger const DefaultMaximumRequests = 6;
         }
         self.transportPushChannel = [[pushChannelClass alloc] initWithScheduler:self.requestScheduler
                                                                 userAgentString:userAgent
-                                                                    environment:environment];
+                                                                    environment:environment
+                                                                          queue:queue];
 
         self.firstRequestFired = NO;
         self.accessTokenHandler = [[ZMAccessTokenHandler alloc] initWithBaseURL:self.baseURL

--- a/Tests/Source/PushChannel/NativePushChannelTests+ServerTrust.swift
+++ b/Tests/Source/PushChannel/NativePushChannelTests+ServerTrust.swift
@@ -56,7 +56,8 @@ class NativePushChannelTests_ServerTrust: XCTestCase {
 
         sut = NativePushChannel(scheduler: scheduler,
                                 userAgentString: "user-agent",
-                                environment: mockEnvironment)
+                                environment: mockEnvironment,
+                                queue: .main)
     }
 
     override func tearDownWithError() throws {

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -228,6 +228,7 @@ static FakePushChannel *currentFakePushChannel;
 @synthesize keepOpen;
 
 - (instancetype)initWithScheduler:(ZMTransportRequestScheduler *)scheduler userAgentString:(NSString *)userAgentString environment:(id<BackendEnvironmentProvider>)environment
+                            queue:(NSOperationQueue * _Nonnull)queue
 {
     self = [super init];
     if (self) {


### PR DESCRIPTION
## What's new in this PR?

### Issues

Sometimes all scheduled requests starts to timeout. The issue usually revolves it self after moving the the app into the background/foreground.

```
<ZMURLSession 0x28163b520> URLSession:task:didCompleteWithError: -> https://prod-nginz-https.wire.com/notifications?size=500&since=ca30c45a-c934-11eb-8005-22000ac389f3&client=67d81a150c0b3f6b (null), error: Error Domain=NSURLErrorDomain Code=-1001 "The request timed out." UserInfo={_kCFStreamErrorCodeKey=-2102, NSUnderlyingError=0x283b4f000 {Error Domain=kCFErrorDomainCFNetwork Code=-1001 "(null)" UserInfo={_kCFStreamErrorCodeKey=-2102, _kCFStreamErrorDomainKey=4}}, _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <E4962FC1-1A79-44F4-962E-2F625411CC83>.<196>, _NSURLErrorRelatedURLSessionTaskErrorKey=(
    "LocalDataTask <E4962FC1-1A79-44F4-962E-2F625411CC83>.<196>"
), NSLocalizedDescription=The request timed out., NSErrorFailingURLStringKey=https://prod-nginz-https.wire.com/notifications?size=500&since=ca30c45a-c934-11eb-8005-22000ac389f3&client=67d81a150c0b3f6b, NSErrorFailingURLKey=https://prod-nginz-https.wire.com/notifications?size=500&since=ca30c45a-c934-11eb-8005-22000ac389f3&client=67d81a150c0b3f6b, _kCFStreamErrorDomainKey=4}
```


### Causes

It's still unknown what causes this issue but it started to happen a lot more frequently after we started to use the NSURLSession websocket implementation.

### Solutions

The previous attempt to fix this issue https://github.com/wireapp/wire-ios-transport/pull/186 was not working so that change was reverted.

While comparing the old websocket implementation one difference is that all work is happening on the session queue. This PR update the NativePushChannel do all operations on the session queue.