### PR TITLE
[Chore] Fix failing integration tests 

### DIFF
--- a/Source/TransportEncoding/ZMTransportData.m
+++ b/Source/TransportEncoding/ZMTransportData.m
@@ -59,7 +59,7 @@
 
 - (NSDictionary *)asDictionary
 {
-    return nil;
+    return [NSJSONSerialization JSONObjectWithData:[self dataUsingEncoding:NSUTF8StringEncoding] options:0 error:nil];
 }
 
 - (NSArray *)asArray


### PR DESCRIPTION
## What's new in this PR?

### Issues

Mock transport session fails to process requests from The updated `MissingClientsRequestStrategy.

### Causes

The updated `MissingClientsRequestStrategy` is creating the post payload from a struct and is therefore sent as string not as a `NSDictionary`. This becomes a problem in the mock transport session since it expecting the POST payload to be a NSDictionary. 

### Solutions

Implement `asDictionary` when ZMTransportData is a NSString.