### PR TITLE
[Fix] nil out the websocket task when it fails so we can make another attempt

### DIFF
--- a/Source/PushChannel/NativePushChannel.swift
+++ b/Source/PushChannel/NativePushChannel.swift
@@ -167,6 +167,10 @@ class NativePushChannel: NSObject, PushChannelType {
         consumerQueue?.performGroupedBlock {
             self.consumer?.pushChannelDidClose()
         }
+
+        if keepOpen {
+            scheduleOpen()
+        }
     }
 
     private func onOpen() {
@@ -228,7 +232,13 @@ extension NativePushChannel: URLSessionWebSocketDelegate {
 }
 
 @available(iOSApplicationExtension 13.0, iOS 13.0, *)
-extension NativePushChannel: URLSessionDelegate {
+extension NativePushChannel: URLSessionDataDelegate {
+
+    func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        Logging.pushChannel.debug("Websocket open connection task did fail: \(error.map({ String(describing: $0)}) ?? "n/a" )")
+
+        websocketTask = nil
+    }
 
     func urlSession(_ session: URLSession,
                     task: URLSessionTask,


### PR DESCRIPTION
## What's new in this PR?

### Issues

We would not make more than one attempt to open the websocket connection

### Causes

The failed websocket task was not nilled out, which prevented any further attempts to be made.

### Solutions

Implement the delegate for when the task fails and nil out the websocket task.