### PR TITLE
[Feature] Support authenticating request by cookie and access token

### DIFF
--- a/Source/Public/ZMTransportRequest.h
+++ b/Source/Public/ZMTransportRequest.h
@@ -72,6 +72,7 @@ typedef NS_ENUM(uint8_t, ZMTransportRequestMethod) {
 typedef NS_ENUM(uint8_t, ZMTransportRequestAuth) {
     ZMTransportRequestAuthNone, ///< Does not needs an access token and does not generate one
     ZMTransportRequestAuthNeedsAccess, ///< Needs an access token
+    ZMTransportRequestAuthNeedsAccessAndCookie, ///< Needs an access token and a cookie
     ZMTransportRequestAuthCreatesCookieAndAccessToken, ///< Does not need an access token, but the response will contain one
 };
 
@@ -117,6 +118,7 @@ typedef NS_ENUM(int8_t, ZMTransportAccept) {
 @property (nonatomic, readonly, nullable) NSURL *fileUploadURL;
 @property (nonatomic, readonly, copy, nullable) NSString *binaryDataType; ///< Uniform type identifier (UTI) of the binary data
 @property (nonatomic, readonly) BOOL needsAuthentication;
+@property (nonatomic, readonly) BOOL needsAuthenticationCookie;
 @property (nonatomic, readonly) BOOL responseWillContainAccessToken;
 @property (nonatomic, readonly) BOOL responseWillContainCookie;
 @property (nonatomic, readonly, nullable) NSDate *expirationDate;

--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -139,6 +139,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 @property (nonatomic) NSMutableArray <ZMCompletionHandler *> *completionHandlers;
 @property (nonatomic) NSMutableArray <ZMTaskProgressHandler *> *progressHandlers;
 @property (nonatomic) BOOL needsAuthentication;
+@property (nonatomic) BOOL needsAuthenticationCookie;
 @property (nonatomic) BOOL responseWillContainAccessToken;
 @property (nonatomic) BOOL responseWillContainCookie;
 @property (nonatomic) ZMTransportAccept acceptedResponseMediaTypes; ///< C.f. RFC 7231 section 5.3.2 <http://tools.ietf.org/html/rfc7231#section-5.3.2>
@@ -170,14 +171,19 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     return [self initWithPath:path method:method payload:payload authentication:ZMTransportRequestAuthNeedsAccess shouldCompress:shouldCompress];
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication shouldCompress:(BOOL)shouldCompress;
+- (instancetype)initWithPath:(NSString *)path
+                      method:(ZMTransportRequestMethod)method
+                     payload:(id <ZMTransportData>)payload
+              authentication:(ZMTransportRequestAuth)authentication
+              shouldCompress:(BOOL)shouldCompress;
 {
     self = [super init];
     if (self) {
         self.payload = payload;
         self.path = path;
         self.method = method;
-        self.needsAuthentication = (authentication == ZMTransportRequestAuthNeedsAccess);
+        self.needsAuthentication = (authentication == ZMTransportRequestAuthNeedsAccess || authentication == ZMTransportRequestAuthNeedsAccessAndCookie);
+        self.needsAuthenticationCookie = (authentication == ZMTransportRequestAuthNeedsAccessAndCookie);
         self.responseWillContainAccessToken = (authentication == ZMTransportRequestAuthCreatesCookieAndAccessToken);
         self.responseWillContainCookie = (authentication == ZMTransportRequestAuthCreatesCookieAndAccessToken);
         self.acceptedResponseMediaTypes = ZMTransportAcceptTransportData;
@@ -258,6 +264,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
         self.binaryDataType = type;
         self.contentDisposition = contentDisposition;
         self.needsAuthentication = YES;
+        self.needsAuthenticationCookie = NO;
         self.responseWillContainAccessToken = NO;
         self.acceptedResponseMediaTypes = ZMTransportAcceptTransportData;
         self.shouldCompress = shouldCompress;

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -451,6 +451,10 @@ static NSInteger const DefaultMaximumRequests = 6;
                           usingBackgroundSession:session.isBackgroundSession];
     
     [self.accessTokenHandler checkIfRequest:request needsToFetchAccessTokenInURLRequest:URLRequest];
+
+    if (request.needsAuthenticationCookie) {
+        [self.cookieStorage setRequestHeaderFieldsOnRequest:URLRequest];
+    }
     
     NSData *bodyData = URLRequest.HTTPBody;
     URLRequest.HTTPBody = nil;


### PR DESCRIPTION
## What's new in this PR?

Introduce `ZMTransportRequestAuthNeedsAccessAndCookie` to signal that request needs both the authentication cookie and the access token headers.