### PR TITLE
remove ios 10 SecCertificateCopyPublicKey wrapper

### DIFF
--- a/Source/Public/TrustData.swift
+++ b/Source/Public/TrustData.swift
@@ -43,7 +43,7 @@ struct TrustData: Decodable {
             throw DecodingError.dataCorruptedError(forKey: CodingKeys.certificateKey, in: container, debugDescription: "Error decoding certificate for pinned key")
         }
         
-        guard let certificateKey = _SecCertificateCopyPublicKey(certificate) else {
+        guard let certificateKey = SecCertificateCopyKey(certificate) else {
             throw DecodingError.dataCorruptedError(forKey: CodingKeys.certificateKey, in: container, debugDescription: "Error extracting pinned key from certificate")
         }
         self.certificateKey = certificateKey

--- a/Source/URLSession/ZMServerTrust.h
+++ b/Source/URLSession/ZMServerTrust.h
@@ -22,10 +22,5 @@ CF_IMPLICIT_BRIDGING_ENABLED
 
 extern BOOL verifyServerTrustWithPinnedKeys(SecTrustRef const serverTrust, NSArray * pinnedKeys);
 
-// A wrapper to use SecCertificateCopyPublicKey from Swift because it is marked as introduced in 10.3 and forces to bump deployment target to iOS 10.3
-// We have started using this method because we needed to be compatible with iOS8 (see https://github.com/wireapp/wire-ios-transport/pull/33)
-// It is probably incorrectly marked in Foundation API headers, because it is clearly available in earlier iOS versions (we had this in production for a long time).
-extern __nullable SecKeyRef _SecCertificateCopyPublicKey(SecCertificateRef certificate);
-
 CF_ASSUME_NONNULL_END
 CF_IMPLICIT_BRIDGING_DISABLED

--- a/Source/URLSession/ZMServerTrust.m
+++ b/Source/URLSession/ZMServerTrust.m
@@ -76,14 +76,6 @@ static SecKeyRef publicKeyAssociatedWithServerTrust(SecTrustRef const serverTrus
     return key;
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-__nullable SecKeyRef _SecCertificateCopyPublicKey(__nonnull SecCertificateRef certificate)
-{
-    return SecCertificateCopyPublicKey(certificate);
-}
-#pragma clang diagnostic pop
-
 BOOL verifyServerTrustWithPinnedKeys(SecTrustRef const serverTrust, NSArray *pinnedKeys)
 {    
     SecTrustResultType result;


### PR DESCRIPTION
## What's new in this PR?

Remove the `_SecCertificateCopyPublicKey` wrapper for iOS 8 compatible and replace with `SecCertificateCopyKey`