### PR TITLE
[Fix] Websocket blocking all network requests

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,2 @@
 github "wireapp/wire-ios-utilities" ~> 43.0.0
+github "wireapp/Starscream" ~> 4.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,4 @@
+github "wireapp/Starscream" "4.0.4"
 github "wireapp/ocmock" "v3.4.3_xcframework"
 github "wireapp/wire-ios-system" "35.0.0"
 github "wireapp/wire-ios-testing" "26.0.0"

--- a/Source/PushChannel/StarscreamPushChannel.swift
+++ b/Source/PushChannel/StarscreamPushChannel.swift
@@ -1,0 +1,247 @@
+//
+// Wire
+// Copyright (C) 2021 Wire Swiss GmbH
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program. If not, see http://www.gnu.org/licenses/.
+//
+
+import Foundation
+import Starscream
+
+@available(iOSApplicationExtension 13.0, iOS 13.0, *)
+@objcMembers
+class StarscreamPushChannel: NSObject, PushChannelType {
+
+    var webSocket: WebSocket?
+    var workQueue: OperationQueue
+    let environment: BackendEnvironmentProvider
+    let scheduler: ZMTransportRequestScheduler
+    weak var consumer: ZMPushChannelConsumer?
+    var consumerQueue: ZMSGroupQueue?
+    var pingTimer: ZMTimer?
+
+    var clientID: String? {
+        didSet {
+            Logging.pushChannel.debug("Setting client ID")
+            scheduleOpen()
+        }
+    }
+
+    var accessToken: AccessToken? {
+        didSet {
+            Logging.pushChannel.debug("Setting access token")
+        }
+    }
+
+    var keepOpen: Bool = false {
+        didSet {
+            if keepOpen {
+                scheduleOpen()
+            } else {
+                self.close()
+            }
+        }
+    }
+
+    var canOpenConnection: Bool {
+        return keepOpen && websocketURL != nil && consumer != nil
+    }
+
+    var websocketURL: URL? {
+        let url = environment.backendWSURL.appendingPathComponent("/await")
+        var urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        urlComponents?.queryItems = [URLQueryItem(name: "client", value: clientID)]
+
+        return urlComponents?.url
+    }
+
+    required init(scheduler: ZMTransportRequestScheduler,
+                  userAgentString: String,
+                  environment: BackendEnvironmentProvider, queue: OperationQueue) {
+        self.environment = environment
+        self.scheduler = scheduler
+        self.workQueue = queue
+    }
+
+    func reachabilityDidChange(_ reachability: ReachabilityProvider) {
+        let didGoOnline = reachability.mayBeReachable && !reachability.oldMayBeReachable
+        guard didGoOnline else { return }
+
+        scheduleOpen()
+    }
+
+    func setPushChannelConsumer(_ consumer: ZMPushChannelConsumer?, queue: ZMSGroupQueue) {
+        self.consumerQueue = queue
+        self.consumer = consumer
+
+        if consumer == nil {
+            close()
+        } else {
+            scheduleOpen()
+        }
+    }
+
+    func close() {
+        Logging.pushChannel.debug("Push channel was closed")
+
+        scheduler.performGroupedBlock {
+            self.webSocket?.disconnect()
+        }
+    }
+
+    func open() {
+        guard
+            keepOpen,
+            webSocket == nil,
+            let accessToken = accessToken,
+            let websocketURL = websocketURL
+        else {
+            return
+        }
+
+        var connectionRequest = URLRequest(url: websocketURL)
+        connectionRequest.setValue("\(accessToken.type) \(accessToken.token)", forHTTPHeaderField: "Authorization")
+
+        let certificatePinning = StarscreamCertificatePinning(environment: environment)
+        webSocket = WebSocket(request: connectionRequest, certPinner: certificatePinning, useCustomEngine: true)
+        webSocket?.delegate = self
+        if let queue = workQueue.underlyingQueue {
+            webSocket?.callbackQueue = queue
+        }
+        webSocket?.connect()
+
+        Logging.pushChannel.debug("Connecting websocket..")
+    }
+
+    func scheduleOpen() {
+        scheduler.performGroupedBlock { [weak self] in
+            self?.scheduleOpenInternal()
+        }
+    }
+
+    private func scheduleOpenInternal() {
+        guard canOpenConnection else {
+            Logging.pushChannel.debug("Conditions for scheduling opening not fulfilled, waiting...")
+            return
+        }
+        Logging.pushChannel.debug("Schedule opening..")
+        scheduler.add(ZMOpenPushChannelRequest())
+    }
+
+    fileprivate func onClose() {
+        webSocket = nil
+        stopPingTimer()
+
+        consumerQueue?.performGroupedBlock {
+            self.consumer?.pushChannelDidClose()
+        }
+
+        if keepOpen {
+            scheduleOpen()
+        }
+    }
+
+    fileprivate func onOpen() {
+        startPingTimer()
+
+        consumerQueue?.performGroupedBlock({
+            self.consumer?.pushChannelDidOpen()
+        })
+    }
+
+    private func stopPingTimer() {
+        pingTimer?.cancel()
+        pingTimer = nil
+    }
+
+    fileprivate func schedulePingTimer() {
+        stopPingTimer()
+        startPingTimer()
+    }
+
+    fileprivate func startPingTimer() {
+        let timer = ZMTimer(target: self, operationQueue: workQueue)
+        timer?.fire(afterTimeInterval: 30)
+        pingTimer = timer
+    }
+}
+
+@available(iOSApplicationExtension 13.0, iOS 13.0, *)
+extension StarscreamPushChannel: ZMTimerClient {
+
+    func timerDidFire(_ timer: ZMTimer!) {
+        Logging.pushChannel.debug("Sending ping")
+        webSocket?.write(ping: Data())
+        schedulePingTimer()
+    }
+
+}
+
+@available(iOSApplicationExtension 13.0, iOS 13.0, *)
+extension StarscreamPushChannel: WebSocketDelegate {
+
+    func didReceive(event: WebSocketEvent, client: WebSocket) {
+        switch event {
+
+        case .connected(_):
+            Logging.pushChannel.debug("Sending ping")
+            onOpen()
+        case .disconnected(_, _):
+            Logging.pushChannel.debug("Websocket disconnected")
+            onClose()
+        case .text(_):
+            break
+        case .binary(let data):
+            Logging.pushChannel.debug("Received data")
+            guard
+                let transportData = try? JSONSerialization.jsonObject(with: data, options: []) as? ZMTransportData
+            else { break }
+
+            consumerQueue?.performGroupedBlock { [weak self] in
+                self?.consumer?.pushChannelDidReceive(transportData)
+            }
+        case .pong(_):
+            break
+        case .ping(_):
+            break
+        case .error(_):
+            onClose()
+        case .viabilityChanged(_):
+            break
+        case .reconnectSuggested(_):
+            break
+        case .cancelled:
+            onClose()
+        }
+    }
+
+}
+
+class StarscreamCertificatePinning: CertificatePinning {
+
+    let environment: BackendEnvironmentProvider
+
+    init(environment: BackendEnvironmentProvider) {
+        self.environment = environment
+    }
+
+    func evaluateTrust(trust: SecTrust, domain: String?, completion: ((PinningState) -> ())) {
+        if environment.verifyServerTrust(trust: trust, host: domain) {
+            completion(.success)
+        } else {
+            completion(.failed(nil))
+        }
+    }
+
+}

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -263,7 +263,7 @@ static NSInteger const DefaultMaximumRequests = 6;
 
         if (pushChannelClass == nil) {
             if (@available(iOS 13.0, *)) {
-                pushChannelClass = NativePushChannel.class;
+                pushChannelClass = StarscreamPushChannel.class;
             } else {
                 pushChannelClass = ZMTransportPushChannel.class;
             }

--- a/WireTransport.xcodeproj/project.pbxproj
+++ b/WireTransport.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		1650EBDD21CBFE9C00186075 /* MockURLAuthenticationChallengeSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1650EBDC21CBFE9C00186075 /* MockURLAuthenticationChallengeSender.swift */; };
 		166D18BB230EE8A8001288CD /* TransportSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166D18BA230EE8A8001288CD /* TransportSession.swift */; };
 		16D7D9F7265251620049FFCA /* NativePushChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16D7D9F6265251620049FFCA /* NativePushChannel.swift */; };
+		16F900DB26C2CBA4002794B5 /* Starscream.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16F900DA26C2CBA4002794B5 /* Starscream.xcframework */; };
+		16F900E226C2CBE6002794B5 /* StarscreamPushChannel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16F900E126C2CBE6002794B5 /* StarscreamPushChannel.swift */; };
 		3E88BCB31B1F35DF00232589 /* WireTransport.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E88BCA71B1F35DF00232589 /* WireTransport.framework */; };
 		5431ABFF1DB4C35B0040343C /* RequestLoopDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5431ABFE1DB4C35B0040343C /* RequestLoopDetection.swift */; };
 		5431AC011DB4C8330040343C /* RequestLoopDetectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5431AC001DB4C8330040343C /* RequestLoopDetectionTests.swift */; };
@@ -212,6 +214,8 @@
 		1650EBDC21CBFE9C00186075 /* MockURLAuthenticationChallengeSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLAuthenticationChallengeSender.swift; sourceTree = "<group>"; };
 		166D18BA230EE8A8001288CD /* TransportSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TransportSession.swift; sourceTree = "<group>"; };
 		16D7D9F6265251620049FFCA /* NativePushChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativePushChannel.swift; sourceTree = "<group>"; };
+		16F900DA26C2CBA4002794B5 /* Starscream.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = Starscream.xcframework; path = Carthage/Build/Starscream.xcframework; sourceTree = "<group>"; };
+		16F900E126C2CBE6002794B5 /* StarscreamPushChannel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StarscreamPushChannel.swift; sourceTree = "<group>"; };
 		3E88BCA71B1F35DF00232589 /* WireTransport.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WireTransport.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E88BCB21B1F35DF00232589 /* WireTransport-ios-tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "WireTransport-ios-tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		3E88BD211B1F383000232589 /* WireTransport-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "WireTransport-Info.plist"; sourceTree = "<group>"; };
@@ -388,6 +392,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A96E0106265FF7D10034A057 /* WireSystem.xcframework in Frameworks */,
+				16F900DB26C2CBA4002794B5 /* Starscream.xcframework in Frameworks */,
 				A96E0108265FF7D10034A057 /* WireUtilities.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -476,6 +481,7 @@
 		3E88BDE01B1F44FB00232589 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				16F900DA26C2CBA4002794B5 /* Starscream.xcframework */,
 				A96E010C265FF7D90034A057 /* OCMock.xcframework */,
 				A96E010B265FF7D90034A057 /* WireTesting.xcframework */,
 				A96E0104265FF7D10034A057 /* WireSystem.xcframework */,
@@ -644,6 +650,7 @@
 				5499FF7D1B31C66C00835C8B /* ZMWebSocketHandshake.h */,
 				5499FF7E1B31C66C00835C8B /* ZMWebSocketHandshake.m */,
 				16D7D9F6265251620049FFCA /* NativePushChannel.swift */,
+				16F900E126C2CBE6002794B5 /* StarscreamPushChannel.swift */,
 			);
 			path = PushChannel;
 			sourceTree = "<group>";
@@ -1047,6 +1054,7 @@
 				54B4D9E11E840C7E00F2892B /* NSURLSessionConfiguration+Debugging.swift in Sources */,
 				54CA15CB1B32F2C1008D3787 /* ZMTransportSession.m in Sources */,
 				F19E555D22B27915005C792D /* ZMTransportResponse.swift in Sources */,
+				16F900E226C2CBE6002794B5 /* StarscreamPushChannel.swift in Sources */,
 				16D7D9F7265251620049FFCA /* NativePushChannel.swift in Sources */,
 				5451EFA01B7A138B002F503B /* Collections+ZMTSafeTypes.m in Sources */,
 				F1D1281821C1556E0090045E /* BackendEnvironmentProvider.swift in Sources */,


### PR DESCRIPTION
## What's new in this PR?

### Issues

Apples native websocket implementation sometimes starts blocking all other network requests.

### Causes

After several days spent debugging this, the root cause is still unknown. I'll open a support ticket with Apple debug this further.

### Solutions

While we are waiting for feedback from Apple I'm adding an alternative websocket implementation based on the Starscream framework.

### Notes

This is an API breaker since I'm adding a new Carthage dependency.