### PR TITLE
Fix: refactor objc NSKeyedArchiver deprecated methods

### DIFF
--- a/Source/Authentication/ZMPersistentCookieStorage.m
+++ b/Source/Authentication/ZMPersistentCookieStorage.m
@@ -383,15 +383,12 @@ static dispatch_queue_t isolationQueue()
         return;
     }
     
-    NSMutableData *data = [NSMutableData data];
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initForWritingWithMutableData:data];
-#pragma clang diagnostic pop
-    archiver.requiresSecureCoding = YES;
+    NSKeyedArchiver *archiver = [[NSKeyedArchiver alloc] initRequiringSecureCoding:YES];
     [archiver encodeObject:properties forKey:@"properties"];
     [archiver finishEncoding];
-    
+
+    NSData *data = [archiver encodedData];
+
     if (TARGET_OS_IPHONE) {
         NSData *secretKey = [NSUserDefaults cookiesKey];
         data = [[data zmEncryptPrefixingIVWithKey:secretKey] mutableCopy];

--- a/Tests/Source/TransportSession/HTTPCookie+HelperTests.swift
+++ b/Tests/Source/TransportSession/HTTPCookie+HelperTests.swift
@@ -56,7 +56,7 @@ final class HTTPCookieHelperTests: XCTestCase {
         
         // then
         guard let decryptedData = Data(base64Encoded: data)?.zmDecryptPrefixedIV(key: UserDefaults.cookiesKey()) else { return XCTFail("failed to decrypt") }
-        let unarchiver = NSKeyedUnarchiver(forReadingWith: decryptedData)
+        let unarchiver = try! NSKeyedUnarchiver(forReadingFrom: decryptedData)
         unarchiver.requiresSecureCoding = true
         
         guard let propertiesArray = unarchiver.decodePropertyList(forKey: "properties") as? [[String: Any]] else { return XCTFail("no properties") }


### PR DESCRIPTION
## What's new in this PR?

Refactor objc NSKeyedArchiver deprecated methods