### PR TITLE
refactor ZMTaskIdentifier to support NSKeyedUnarchiver unarchivedObjectOfClass

### DIFF
--- a/Source/Authentication/ZMPersistentCookieStorage.m
+++ b/Source/Authentication/ZMPersistentCookieStorage.m
@@ -194,19 +194,18 @@ static dispatch_queue_t isolationQueue()
         NSData *secretKey = [NSUserDefaults cookiesKey];
         data = [data zmDecryptPrefixedIVWithKey:secretKey];
     }
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
     NSKeyedUnarchiver *unarchiver;
     @try {
-        unarchiver = [[NSKeyedUnarchiver alloc] initForReadingWithData:data];
+        NSError *error = nil;
+        unarchiver = [[NSKeyedUnarchiver alloc] initForReadingFromData:data error:&error];
+        
+        if (error != nil || unarchiver == nil) {
+            ZMLogError(@"Unable to parse stored cookie data.");
+            self.authenticationCookieData = nil;
+            return nil;
+        }
     } @catch (id) {
-
-        ZMLogError(@"Unable to parse stored cookie data.");
-        self.authenticationCookieData = nil;
-        return nil;
-    }
-#pragma clang diagnostic pop
-    if (unarchiver == nil) {
         ZMLogError(@"Unable to parse stored cookie data.");
         self.authenticationCookieData = nil;
         return nil;

--- a/Source/URLSession/ZMTaskIdentifier.h
+++ b/Source/URLSession/ZMTaskIdentifier.h
@@ -19,7 +19,7 @@
 
 #import <Foundation/Foundation.h>
 
-@interface ZMTaskIdentifier : NSObject <NSCoding>
+@interface ZMTaskIdentifier : NSObject <NSCoding, NSSecureCoding>
 
 @property (nonatomic, readonly) NSUInteger identifier;
 @property (nonatomic, readonly) NSString *sessionIdentifier;

--- a/Source/URLSession/ZMTaskIdentifier.m
+++ b/Source/URLSession/ZMTaskIdentifier.m
@@ -65,6 +65,11 @@ static NSString * const SessionIdentifierKey = @"sessionIdentifier";
     return nil;
 }
 
++ (BOOL)supportsSecureCoding
+{
+    return YES;
+}
+
 - (NSData *)data
 {
     return [NSKeyedArchiver archivedDataWithRootObject:self];

--- a/Tests/Source/URLSession/ZMTaskIdentifierTests.m
+++ b/Tests/Source/URLSession/ZMTaskIdentifierTests.m
@@ -59,23 +59,20 @@
     XCTAssertNotEqualObjects(second, third);
 }
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
 - (void)testThatItCanBeSerializedAndDeserializedFromAndToNSData {
     // given
     ZMTaskIdentifier *sut = [ZMTaskIdentifier identifierWithIdentifier:46 sessionIdentifier:@"foreground-session"];
     XCTAssertNotNil(sut);
     
     // when
-    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:sut];
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:sut requiringSecureCoding:NO error:nil];
     XCTAssertNotNil(data);
     
     // then
-    ZMTaskIdentifier *deserializedSut = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    ZMTaskIdentifier *deserializedSut = [NSKeyedUnarchiver unarchivedObjectOfClass:ZMTaskIdentifier.class fromData:data error:nil];
     XCTAssertNotNil(deserializedSut);
     XCTAssertEqualObjects(deserializedSut, sut);
 }
-#pragma clang diagnostic pop
 
 - (void)testThatItCanBeInitializedFromDataAndReturnsTheCorrectData {
     // given


### PR DESCRIPTION
## What's new in this PR?

Add `NSSecureCoding` to `ZMTaskIdentifier` to make it support new `NSKeyedUnarchiver unarchivedObjectOfClass:` instead of deprecated `NSKeyedUnarchiver unarchiveObjectWithData:`