### PR TITLE
ci: Add semantic commit linting of PR titles SQPIT-769

### DIFF
--- a/.github/workflows/semantic-commit-lint.yml
+++ b/.github/workflows/semantic-commit-lint.yml
@@ -1,0 +1,64 @@
+name: "Semantic Commit Linting of PR titles"
+
+on:
+  pull_request:
+    types: [ opened, edited, synchronize ]
+
+jobs:
+  semantic-commit-pr-title-lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      CUSTOM_PR_LABEL: "Fix PR Title 🤦‍♂️"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          
+      - name: Set environment variables
+        run: | 
+          echo "HEAD=${{github.head_ref}}" >> $GITHUB_ENV
+          
+      # Please look up the latest version from
+      # https://github.com/amannn/action-semantic-pull-request/releases
+      - name: Run Semantic Commint Linter
+        uses: amannn/action-semantic-pull-request@v3.4.6
+        with:
+          # Configure which types are allowed.
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            breaking
+            build
+            ci
+            chore
+            docs
+            feat
+            fix
+            other
+            perf
+            refactor
+            revert
+            style
+            test
+          # For work-in-progress PRs you can typically use draft pull requests 
+          # from Github. However, private repositories on the free plan don't have 
+          # this option and therefore this action allows you to opt-in to using the 
+          # special "[WIP]" prefix to indicate this state. This will avoid the 
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: true
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit message for one commit PRs.
+          validateSingleCommit: true
+      - name: Add Failure Label
+        if: failure()
+        run: |
+          gh api repos/{owner}/{repo}/labels -f name="${CUSTOM_PR_LABEL}" -f color="FF0000" || true
+          gh pr edit "${HEAD}" --add-label "${CUSTOM_PR_LABEL}"
+      - name: Remove Failure Label
+        if: success()
+        run: |
+          gh pr edit "${HEAD}" --remove-label "${CUSTOM_PR_LABEL}"


### PR DESCRIPTION
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

We want to ensure that PR titles follow semantic commit rules

### Solutions

Add the semantic commit linter workflow from Wire's .github repo

### Testing

N/A

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
