### PR TITLE
feat: add api version to requests and responses FS-481

### DIFF
--- a/Source/Authentication/ZMAccessTokenHandler.h
+++ b/Source/Authentication/ZMAccessTokenHandler.h
@@ -56,7 +56,7 @@
 /// Returns YES if another request should be generated (e.g. it was a temporary error)
 - (BOOL)processAccessTokenResponse:(ZMTransportResponse *)response;
 
-- (BOOL)consumeRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry;
+- (BOOL)consumeRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry apiVersion:(int)apiVersion
 ;
 
 - (BOOL)hasAccessToken;

--- a/Source/Authentication/ZMAccessTokenHandler.h
+++ b/Source/Authentication/ZMAccessTokenHandler.h
@@ -56,7 +56,7 @@
 /// Returns YES if another request should be generated (e.g. it was a temporary error)
 - (BOOL)processAccessTokenResponse:(ZMTransportResponse *)response;
 
-- (BOOL)consumeRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry apiVersion:(int)apiVersion
+- (BOOL)consumeRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry apiVersion:(ZMAPIVersion)apiVersion
 ;
 
 - (BOOL)hasAccessToken;

--- a/Source/Authentication/ZMAccessTokenHandler.m
+++ b/Source/Authentication/ZMAccessTokenHandler.m
@@ -211,24 +211,24 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
 
 
 
-- (BOOL)consumeRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry;
+- (BOOL)consumeRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry apiVersion:(int)apiVersion;
 {
     if (self.currentAccessTokenTask != task) {
         return NO;
     }
 
-    [self didCompleteAccessTokenRequestWithTask:task data:data session:session shouldRetry:shouldRetry];
+    [self didCompleteAccessTokenRequestWithTask:task data:data session:session shouldRetry:shouldRetry apiVersion:apiVersion];
     return YES;
 }
 
 
-- (void)didCompleteAccessTokenRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry
+- (void)didCompleteAccessTokenRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry apiVersion:(int)apiVersion
 {
     ZMLogInfo(@"<---- Access token task completed: %@ // %@", task, task.error);
     ZMLogInfo(@"<---- Access token URL session: %@", session.description);
     
     NSError *transportError = [NSError transportErrorFromURLTask:task expired:NO];
-    ZMTransportResponse *response = [self transportResponseFromURLResponse:task.response data:data error:transportError];
+    ZMTransportResponse *response = [self transportResponseFromURLResponse:task.response data:data error:transportError apiVersion:apiVersion];
     BOOL needToResend = [self processAccessTokenResponse:response];
     
     // We can only re-send once we've cleared out the current
@@ -265,10 +265,10 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
 }
 
 
-- (ZMTransportResponse *)transportResponseFromURLResponse:(NSURLResponse *)URLResponse data:(NSData *)data error:(NSError *)error;
+- (ZMTransportResponse *)transportResponseFromURLResponse:(NSURLResponse *)URLResponse data:(NSData *)data error:(NSError *)error apiVersion:(int)apiVersion;
 {
     NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *) URLResponse;
-    return [[ZMTransportResponse alloc] initWithHTTPURLResponse:HTTPResponse data:data error:error];
+    return [[ZMTransportResponse alloc] initWithHTTPURLResponse:HTTPResponse data:data error:error apiVersion:apiVersion];
 }
 
 

--- a/Source/Authentication/ZMAccessTokenHandler.m
+++ b/Source/Authentication/ZMAccessTokenHandler.m
@@ -211,7 +211,7 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
 
 
 
-- (BOOL)consumeRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry apiVersion:(int)apiVersion;
+- (BOOL)consumeRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry apiVersion:(ZMAPIVersion)apiVersion;
 {
     if (self.currentAccessTokenTask != task) {
         return NO;
@@ -222,7 +222,7 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
 }
 
 
-- (void)didCompleteAccessTokenRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry apiVersion:(int)apiVersion
+- (void)didCompleteAccessTokenRequestWithTask:(NSURLSessionTask *)task data:(NSData *)data session:(ZMURLSession *)session shouldRetry:(BOOL)shouldRetry apiVersion:(ZMAPIVersion)apiVersion
 {
     ZMLogInfo(@"<---- Access token task completed: %@ // %@", task, task.error);
     ZMLogInfo(@"<---- Access token URL session: %@", session.description);
@@ -265,7 +265,7 @@ static NSTimeInterval const GraceperiodToRenewAccessToken = 40;
 }
 
 
-- (ZMTransportResponse *)transportResponseFromURLResponse:(NSURLResponse *)URLResponse data:(NSData *)data error:(NSError *)error apiVersion:(int)apiVersion;
+- (ZMTransportResponse *)transportResponseFromURLResponse:(NSURLResponse *)URLResponse data:(NSData *)data error:(NSError *)error apiVersion:(ZMAPIVersion)apiVersion;
 {
     NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *) URLResponse;
     return [[ZMTransportResponse alloc] initWithHTTPURLResponse:HTTPResponse data:data error:error apiVersion:apiVersion];

--- a/Source/Public/WireTransport.h
+++ b/Source/Public/WireTransport.h
@@ -48,6 +48,7 @@ FOUNDATION_EXPORT const unsigned char TransportVersionString[];
 #import <WireTransport/ZMTaskIdentifier.h>
 #import <WireTransport/ZMRequestCancellation.h>
 #import <WireTransport/ZMPushChannel.h>
+#import <WireTransport/ZMAPIVersion.h>
 
 // Private
 

--- a/Source/Public/ZMAPIVersion.h
+++ b/Source/Public/ZMAPIVersion.h
@@ -21,7 +21,7 @@
 /// Represents the backend API versions supported by the client.
 ///
 /// Remove versions to drop support, add versions to add support.
-/// Any changes made here are consider breaking and the compiler
+/// Any changes made here are considered breaking and the compiler
 /// can then be used to ensure that changes can be accounted for.
 
 typedef NS_ENUM(NSInteger, ZMAPIVersion) {

--- a/Source/Public/ZMAPIVersion.h
+++ b/Source/Public/ZMAPIVersion.h
@@ -1,24 +1,29 @@
-// 
+//
 // Wire
-// Copyright (C) 2016 Wire Swiss GmbH
-// 
+// Copyright (C) 2022 Wire Swiss GmbH
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
-// 
+//
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY; without even the implied warranty of
 // MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 // GNU General Public License for more details.
-// 
+//
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see http://www.gnu.org/licenses/.
-// 
+//
 
+#import <Foundation/Foundation.h>
 
-@interface ZMTransportRequest (AssetGet)
+/// Represents the backend API versions supported by the client.
+///
+/// Remove versions to drop support, add versions to add support.
+/// Any changes made here are consider breaking and the compiler
+/// can then be used to ensure that changes can be accounted for.
 
-+ (nullable instancetype)assetGetRequestFromPath:(nonnull NSString *)path assetToken:(nullable NSString *)token apiVersion:(ZMAPIVersion)apiVersion;
-
-@end
+typedef NS_ENUM(NSInteger, ZMAPIVersion) {
+    v0 = 0
+};

--- a/Source/Public/ZMTransportRequest+AssetGet.h
+++ b/Source/Public/ZMTransportRequest+AssetGet.h
@@ -19,6 +19,6 @@
 
 @interface ZMTransportRequest (AssetGet)
 
-+ (nullable instancetype)assetGetRequestFromPath:(nonnull NSString *)path assetToken:(nullable NSString *)token;
++ (nullable instancetype)assetGetRequestFromPath:(nonnull NSString *)path assetToken:(nullable NSString *)token apiVersion:(int)apiVersion;
 
 @end

--- a/Source/Public/ZMTransportRequest.h
+++ b/Source/Public/ZMTransportRequest.h
@@ -20,6 +20,7 @@
 
 #import <Foundation/Foundation.h>
 #import <WireSystem/WireSystem.h>
+#import <WireTransport/ZMAPIVersion.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -89,25 +90,25 @@ typedef NS_ENUM(int8_t, ZMTransportAccept) {
 + (ZMTransportRequestMethod)methodFromString:(NSString *)string;
 
 /// Returns a request that needs authentication, ie. @c ZMTransportRequestAuthNeedsAccess
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload apiVersion:(int)apiVersion;
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication apiVersion:(int)apiVersion;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload apiVersion:(ZMAPIVersion)apiVersion;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication apiVersion:(ZMAPIVersion)apiVersion;
 
-+ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload apiVersion:(int)apiVersion;
-+ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
++ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload apiVersion:(ZMAPIVersion)apiVersion;
++ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress apiVersion:(ZMAPIVersion)apiVersion;
 
-+ (instancetype)requestGetFromPath:(NSString *)path apiVersion:(int)apiVersion;
-+ (instancetype)compressedGetFromPath:(NSString *)path apiVersion:(int)apiVersion;
-+ (instancetype)uploadRequestWithFileURL:(NSURL *)url path:(NSString *)path contentType:(NSString *)contentType apiVersion:(int)apiVersion;
++ (instancetype)requestGetFromPath:(NSString *)path apiVersion:(ZMAPIVersion)apiVersion;
++ (instancetype)compressedGetFromPath:(NSString *)path apiVersion:(ZMAPIVersion)apiVersion;
++ (instancetype)uploadRequestWithFileURL:(NSURL *)url path:(NSString *)path contentType:(NSString *)contentType apiVersion:(ZMAPIVersion)apiVersion;
 
-+ (instancetype)emptyPutRequestWithPath:(NSString *)path apiVersion:(int)apiVersion;
-+ (instancetype)imageGetRequestFromPath:(NSString *)path apiVersion:(int)apiVersion;
++ (instancetype)emptyPutRequestWithPath:(NSString *)path apiVersion:(ZMAPIVersion)apiVersion;
++ (instancetype)imageGetRequestFromPath:(NSString *)path apiVersion:(ZMAPIVersion)apiVersion;
 
 /// Creates a request with the given @c binary data for the body and the given @c type to be used as the content type.
 /// @c type is a (Uniform Type Identifier) UTI.
 /// @link https://en.wikipedia.org/wiki/Uniform_Type_Identifier @/link
 /// @link https://developer.apple.com/library/ios/documentation/General/Conceptual/DevPedia-CocoaCore/UniformTypeIdentifier.html @/link
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type contentDisposition:(nullable NSDictionary *)contentDisposition apiVersion:(int)apiVersion;
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type contentDisposition:(nullable NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type contentDisposition:(nullable NSDictionary *)contentDisposition apiVersion:(ZMAPIVersion)apiVersion;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type contentDisposition:(nullable NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress apiVersion:(ZMAPIVersion)apiVersion;
 
 
 @property (nonatomic, readonly) NSString *methodAsString;
@@ -131,7 +132,7 @@ typedef NS_ENUM(int8_t, ZMTransportAccept) {
 /// In order to correctly handle the response to this request, the api version must
 /// be taking into account. Each request is paired with a response, so the api version
 /// of the response can be derived from this value.
-@property (nonatomic, readonly) int apiVersion;
+@property (nonatomic, readonly) ZMAPIVersion apiVersion;
 
 /// If true, the request should only be sent through background session
 @property (nonatomic, readonly) BOOL shouldUseOnlyBackgroundSession;
@@ -165,16 +166,16 @@ typedef NS_ENUM(int8_t, ZMTransportAccept) {
 
 @interface ZMTransportRequest (ImageUpload)
 
-+ (_Null_unspecified instancetype)postRequestWithPath:(NSString *)path imageData:(NSData *)data contentDisposition:(NSDictionary *)contentDisposition apiVersion:(int)apiVersion;
-+ (_Null_unspecified instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)data metaData:(NSDictionary *)metaData apiVersion:(int)apiVersion;
-+ (_Null_unspecified instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)data metaData:(NSDictionary *)metaData mediaContentType:(NSString *)mediaContentType apiVersion:(int)apiVersion;
++ (_Null_unspecified instancetype)postRequestWithPath:(NSString *)path imageData:(NSData *)data contentDisposition:(NSDictionary *)contentDisposition apiVersion:(ZMAPIVersion)apiVersion;
++ (_Null_unspecified instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)data metaData:(NSDictionary *)metaData apiVersion:(ZMAPIVersion)apiVersion;
++ (_Null_unspecified instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)data metaData:(NSDictionary *)metaData mediaContentType:(NSString *)mediaContentType apiVersion:(ZMAPIVersion)apiVersion;
 
 + (instancetype)multipartRequestWithPath:(NSString *)path
                                imageData:(NSData *)data
                                 metaData:(NSData *)metaData
                      metaDataContentType:(NSString *)metaDataContentType
                         mediaContentType:(NSString *)mediaContentType
-                              apiVersion:(int)apiVersion;
+                              apiVersion:(ZMAPIVersion)apiVersion;
 
 - (nullable NSArray *)multipartBodyItems;
 

--- a/Source/Public/ZMTransportRequest.h
+++ b/Source/Public/ZMTransportRequest.h
@@ -89,25 +89,25 @@ typedef NS_ENUM(int8_t, ZMTransportAccept) {
 + (ZMTransportRequestMethod)methodFromString:(NSString *)string;
 
 /// Returns a request that needs authentication, ie. @c ZMTransportRequestAuthNeedsAccess
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload;
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload apiVersion:(int)apiVersion;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication apiVersion:(int)apiVersion;
 
-+ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload;
-+ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress;
++ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload apiVersion:(int)apiVersion;
++ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(nullable id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
 
-+ (instancetype)requestGetFromPath:(NSString *)path;
-+ (instancetype)compressedGetFromPath:(NSString *)path;
-+ (instancetype)uploadRequestWithFileURL:(NSURL *)url path:(NSString *)path contentType:(NSString *)contentType;
++ (instancetype)requestGetFromPath:(NSString *)path apiVersion:(int)apiVersion;
++ (instancetype)compressedGetFromPath:(NSString *)path apiVersion:(int)apiVersion;
++ (instancetype)uploadRequestWithFileURL:(NSURL *)url path:(NSString *)path contentType:(NSString *)contentType apiVersion:(int)apiVersion;
 
-+ (instancetype)emptyPutRequestWithPath:(NSString *)path;
-+ (instancetype)imageGetRequestFromPath:(NSString *)path;
++ (instancetype)emptyPutRequestWithPath:(NSString *)path apiVersion:(int)apiVersion;
++ (instancetype)imageGetRequestFromPath:(NSString *)path apiVersion:(int)apiVersion;
 
 /// Creates a request with the given @c binary data for the body and the given @c type to be used as the content type.
 /// @c type is a (Uniform Type Identifier) UTI.
 /// @link https://en.wikipedia.org/wiki/Uniform_Type_Identifier @/link
 /// @link https://developer.apple.com/library/ios/documentation/General/Conceptual/DevPedia-CocoaCore/UniformTypeIdentifier.html @/link
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type contentDisposition:(nullable NSDictionary *)contentDisposition;
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type contentDisposition:(nullable NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type contentDisposition:(nullable NSDictionary *)contentDisposition apiVersion:(int)apiVersion;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type contentDisposition:(nullable NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
 
 
 @property (nonatomic, readonly) NSString *methodAsString;
@@ -125,6 +125,13 @@ typedef NS_ENUM(int8_t, ZMTransportAccept) {
 @property (nonatomic, readonly) BOOL shouldCompress;
 @property (nonatomic) BOOL shouldFailInsteadOfRetry;
 @property (nonatomic) BOOL doesNotFollowRedirects;
+
+/// The api version for which this request was made against.
+///
+/// In order to correctly handle the response to this request, the api version must
+/// be taking into account. Each request is paired with a response, so the api version
+/// of the response can be derived from this value.
+@property (nonatomic, readonly) int apiVersion;
 
 /// If true, the request should only be sent through background session
 @property (nonatomic, readonly) BOOL shouldUseOnlyBackgroundSession;
@@ -158,16 +165,16 @@ typedef NS_ENUM(int8_t, ZMTransportAccept) {
 
 @interface ZMTransportRequest (ImageUpload)
 
-+ (_Null_unspecified instancetype)postRequestWithPath:(NSString *)path imageData:(NSData *)data contentDisposition:(NSDictionary *)contentDisposition;
-
-+ (_Null_unspecified instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)data metaData:(NSDictionary *)metaData;
-+ (_Null_unspecified instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)data metaData:(NSDictionary *)metaData mediaContentType:(NSString *)mediaContentType;
++ (_Null_unspecified instancetype)postRequestWithPath:(NSString *)path imageData:(NSData *)data contentDisposition:(NSDictionary *)contentDisposition apiVersion:(int)apiVersion;
++ (_Null_unspecified instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)data metaData:(NSDictionary *)metaData apiVersion:(int)apiVersion;
++ (_Null_unspecified instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)data metaData:(NSDictionary *)metaData mediaContentType:(NSString *)mediaContentType apiVersion:(int)apiVersion;
 
 + (instancetype)multipartRequestWithPath:(NSString *)path
                                imageData:(NSData *)data
                                 metaData:(NSData *)metaData
                      metaDataContentType:(NSString *)metaDataContentType
-                        mediaContentType:(NSString *)mediaContentType;
+                        mediaContentType:(NSString *)mediaContentType
+                              apiVersion:(int)apiVersion;
 
 - (nullable NSArray *)multipartBodyItems;
 

--- a/Source/Public/ZMTransportRequest.h
+++ b/Source/Public/ZMTransportRequest.h
@@ -130,7 +130,7 @@ typedef NS_ENUM(int8_t, ZMTransportAccept) {
 /// The api version for which this request was made against.
 ///
 /// In order to correctly handle the response to this request, the api version must
-/// be taking into account. Each request is paired with a response, so the api version
+/// be taken into account. Each request is paired with a response, so the api version
 /// of the response can be derived from this value.
 @property (nonatomic, readonly) ZMAPIVersion apiVersion;
 

--- a/Source/Public/ZMTransportResponse.h
+++ b/Source/Public/ZMTransportResponse.h
@@ -19,6 +19,7 @@
 
 #import <Foundation/Foundation.h>
 #import <WireTransport/ZMTransportData.h>
+#import <WireTransport/ZMAPIVersion.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -43,14 +44,14 @@ typedef NS_ENUM(uint8_t, ZMTransportResponseStatus) {
 
 @interface ZMTransportResponse : NSObject
 
-- (instancetype)initWithHTTPURLResponse:(NSHTTPURLResponse *)HTTPResponse data:(nullable NSData *)data error:(nullable NSError *)error apiVersion:(int)apiVersion;
+- (instancetype)initWithHTTPURLResponse:(NSHTTPURLResponse *)HTTPResponse data:(nullable NSData *)data error:(nullable NSError *)error apiVersion:(ZMAPIVersion)apiVersion;
 
-- (instancetype)initWithImageData:(NSData *)imageData HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers apiVersion:(int)apiVersion;
+- (instancetype)initWithImageData:(NSData *)imageData HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers apiVersion:(ZMAPIVersion)apiVersion;
 
-- (instancetype)initWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers apiVersion:(int)apiVersion;
-+ (instancetype)responseWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers apiVersion:(int)apiVersion;
-+ (instancetype)responseWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error apiVersion:(int)apiVersion;
-+ (instancetype)responseWithTransportSessionError:(NSError *)error apiVersion:(int)apiVersion;
+- (instancetype)initWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers apiVersion:(ZMAPIVersion)apiVersion;
++ (instancetype)responseWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers apiVersion:(ZMAPIVersion)apiVersion;
++ (instancetype)responseWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error apiVersion:(ZMAPIVersion)apiVersion;
++ (instancetype)responseWithTransportSessionError:(NSError *)error apiVersion:(ZMAPIVersion)apiVersion;
 
 @property (nonatomic, readonly, nullable) id<ZMTransportData> payload;
 @property (nonatomic, readonly, nullable) NSData * imageData;

--- a/Source/Public/ZMTransportResponse.h
+++ b/Source/Public/ZMTransportResponse.h
@@ -70,10 +70,10 @@ typedef NS_ENUM(uint8_t, ZMTransportResponseStatus) {
 
 @property (nonatomic, nullable) NSDate *startOfUploadTimestamp;
 
-/// The api version for associated with the response.
+/// The api version associated with the response.
 ///
 /// In order to correctly handle the response, the api version must
-/// be taking into account, since the response may change over different
+/// be taken into account, since the response may change over different
 /// versions of the same endpoint.
 @property (nonatomic, readonly) int apiVersion;
 @end

--- a/Source/Public/ZMTransportResponse.h
+++ b/Source/Public/ZMTransportResponse.h
@@ -43,14 +43,14 @@ typedef NS_ENUM(uint8_t, ZMTransportResponseStatus) {
 
 @interface ZMTransportResponse : NSObject
 
-- (instancetype)initWithHTTPURLResponse:(NSHTTPURLResponse *)HTTPResponse data:(nullable NSData *)data error:(nullable NSError *)error;
+- (instancetype)initWithHTTPURLResponse:(NSHTTPURLResponse *)HTTPResponse data:(nullable NSData *)data error:(nullable NSError *)error apiVersion:(int)apiVersion;
 
-- (instancetype)initWithImageData:(NSData *)imageData HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers;
+- (instancetype)initWithImageData:(NSData *)imageData HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers apiVersion:(int)apiVersion;
 
-- (instancetype)initWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers;
-+ (instancetype)responseWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers;
-+ (instancetype)responseWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error;
-+ (instancetype)responseWithTransportSessionError:(NSError *)error;
+- (instancetype)initWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers apiVersion:(int)apiVersion;
++ (instancetype)responseWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error headers:(nullable NSDictionary *)headers apiVersion:(int)apiVersion;
++ (instancetype)responseWithPayload:(nullable id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(nullable NSError *)error apiVersion:(int)apiVersion;
++ (instancetype)responseWithTransportSessionError:(NSError *)error apiVersion:(int)apiVersion;
 
 @property (nonatomic, readonly, nullable) id<ZMTransportData> payload;
 @property (nonatomic, readonly, nullable) NSData * imageData;
@@ -68,6 +68,13 @@ typedef NS_ENUM(uint8_t, ZMTransportResponseStatus) {
 - (nullable NSString *)payloadLabel;
 
 @property (nonatomic, nullable) NSDate *startOfUploadTimestamp;
+
+/// The api version for associated with the response.
+///
+/// In order to correctly handle the response, the api version must
+/// be taking into account, since the response may change over different
+/// versions of the same endpoint.
+@property (nonatomic, readonly) int apiVersion;
 @end
 
 

--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -147,6 +147,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 @property (nonatomic) float progress;
 @property (nonatomic) NSMutableDictionary <NSString *, NSString *> *additionalHeaderFields;
 @property (nonatomic) BackgroundActivity *activity;
+@property (nonatomic) int apiVersion;
 
 @end
 
@@ -154,17 +155,17 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 @implementation ZMTransportRequest
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload apiVersion:(int)apiVersion
 {
-    return [self initWithPath:path method:method payload:payload authentication:ZMTransportRequestAuthNeedsAccess shouldCompress:NO];
+    return [self initWithPath:path method:method payload:payload authentication:ZMTransportRequestAuthNeedsAccess shouldCompress:NO apiVersion: apiVersion];
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion
 {
-    return [self initWithPath:path method:method payload:payload authentication:ZMTransportRequestAuthNeedsAccess shouldCompress:shouldCompress];
+    return [self initWithPath:path method:method payload:payload authentication:ZMTransportRequestAuthNeedsAccess shouldCompress:shouldCompress apiVersion: apiVersion];
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication shouldCompress:(BOOL)shouldCompress;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
 {
     self = [super init];
     if (self) {
@@ -179,71 +180,73 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
         self.shouldCompress = shouldCompress;
         self.debugInformation = [NSMutableArray array];
         self.contentDebugInformationHash = payload.hash;
+        self.apiVersion = apiVersion;
     }
     return self;
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication apiVersion:(int)apiVersion;
 {
-    return [self initWithPath:path method:method payload:payload authentication:authentication shouldCompress:NO];
+    return [self initWithPath:path method:method payload:payload authentication:authentication shouldCompress:NO apiVersion:apiVersion];
 }
 
-+ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload
++ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload apiVersion:(int)apiVersion
 {
-    return [[self class] requestWithPath:path method:method payload:payload shouldCompress:NO];
+    return [[self class] requestWithPath:path method:method payload:payload shouldCompress:NO apiVersion:apiVersion];
 }
 
 
-+ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress
++ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion
 {
-    ZMTransportRequest *result = [[self alloc] initWithPath:path method:method payload:payload shouldCompress:shouldCompress];
+    ZMTransportRequest *result = [[self alloc] initWithPath:path method:method payload:payload shouldCompress:shouldCompress apiVersion:apiVersion];
     Require(result.hasRequiredPayload);
     return result;
 }
 
-+ (instancetype)requestGetFromPath:(NSString *)path
++ (instancetype)requestGetFromPath:(NSString *)path apiVersion:(int)apiVersion
 {
-    return [self requestWithPath:path method:ZMMethodGET payload:nil];
+    return [self requestWithPath:path method:ZMMethodGET payload:nil apiVersion:apiVersion];
 }
 
-+ (instancetype)compressedGetFromPath:(NSString *)path
++ (instancetype)compressedGetFromPath:(NSString *)path apiVersion:(int)apiVersion
 {
-    return [self requestWithPath:path method:ZMMethodGET payload:nil shouldCompress:YES];
+    return [self requestWithPath:path method:ZMMethodGET payload:nil shouldCompress:YES apiVersion:apiVersion];
 }
 
-+ (instancetype)uploadRequestWithFileURL:(NSURL *)url path:(NSString *)path contentType:(NSString *)contentType;
++ (instancetype)uploadRequestWithFileURL:(NSURL *)url path:(NSString *)path contentType:(NSString *)contentType apiVersion:(int)apiVersion;
 {
     ZMTransportRequest *request = [[self.class alloc] initWithPath:path
                                                             method:ZMMethodPOST
                                                         binaryData:nil
                                                               type:contentType
-                                                contentDisposition:nil];
+                                                contentDisposition:nil
+                                                        apiVersion:apiVersion];
     request.fileUploadURL = url;
     request.shouldFailInsteadOfRetry = YES;
     [request forceToBackgroundSession];
     return request;
 }
 
-+ (instancetype)emptyPutRequestWithPath:(NSString *)path;
++ (instancetype)emptyPutRequestWithPath:(NSString *)path apiVersion:(int)apiVersion;
 {
     NSString *type = (__bridge NSString *) kUTTypeJSON;
-    return [[self alloc] initWithPath:path method:ZMMethodPUT binaryData:[NSData data] type:type contentDisposition:nil];
+    return [[self alloc] initWithPath:path method:ZMMethodPUT binaryData:[NSData data] type:type contentDisposition:nil apiVersion:apiVersion];
 }
 
-+ (instancetype)imageGetRequestFromPath:(NSString *)path;
++ (instancetype)imageGetRequestFromPath:(NSString *)path apiVersion:(int)apiVersion;
 {
-    ZMTransportRequest *r = [self requestGetFromPath:path];
+    ZMTransportRequest *r = [self requestGetFromPath:path apiVersion:apiVersion];
     r.acceptedResponseMediaTypes = ZMTransportAcceptImage;
     Require(r.hasRequiredPayload);
     return r;
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(NSData *)data type:(NSString *)type contentDisposition:(NSDictionary *)contentDisposition;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(NSData *)data type:(NSString *)type contentDisposition:(NSDictionary *)contentDisposition apiVersion:(int)apiVersion;
 {
-    return [self initWithPath:path method:method binaryData:data type:type contentDisposition:contentDisposition shouldCompress:NO];
+    return [self initWithPath:path method:method binaryData:data type:type contentDisposition:contentDisposition shouldCompress:NO apiVersion:apiVersion];
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(NSData *)data type:(NSString *)type contentDisposition:(NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(NSData *)data type:(NSString *)type contentDisposition:(NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
 {
     self = [super init];
     if (self != nil) {
@@ -258,6 +261,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
         self.shouldCompress = shouldCompress;
         self.debugInformation = [NSMutableArray array];
         self.contentDebugInformationHash = data.hash;
+        self.apiVersion = apiVersion;
     }
     return self;
 }
@@ -729,9 +733,9 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 @implementation ZMTransportRequest (AssetGet)
 
-+ (instancetype)assetGetRequestFromPath:(NSString *)path assetToken:(NSString *)token;
++ (instancetype)assetGetRequestFromPath:(NSString *)path assetToken:(NSString *)token apiVersion:(int)apiVersion;
 {
-    ZMTransportRequest *r = [self requestGetFromPath:path];
+    ZMTransportRequest *r = [self requestGetFromPath:path apiVersion:apiVersion];
     
     if (nil != token) {
         [r addValue:token forAdditionalHeaderField:@"Asset-Token"];
@@ -746,7 +750,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 @implementation ZMTransportRequest (ImageUpload)
 
-+ (instancetype)postRequestWithPath:(NSString *)path imageData:(NSData *)data contentDisposition:(NSDictionary *)contentDisposition;
++ (instancetype)postRequestWithPath:(NSString *)path imageData:(NSData *)data contentDisposition:(NSDictionary *)contentDisposition apiVersion:(int)apiVersion;
 {
     VerifyReturnNil(data != nil);
     CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef) data, NULL);
@@ -756,12 +760,12 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     if (! [UTIHelper conformsToImageTypeWithUti:type]) {
         return nil;
     }
-    ZMTransportRequest *result = [[self alloc] initWithPath:path method:ZMMethodPOST binaryData:data type:type contentDisposition:contentDisposition];
+    ZMTransportRequest *result = [[self alloc] initWithPath:path method:ZMMethodPOST binaryData:data type:type contentDisposition:contentDisposition apiVersion:apiVersion];
     Require(result.hasRequiredPayload);
     return result;
 }
 
-+ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSDictionary *)metaData
++ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSDictionary *)metaData apiVersion:(int)apiVersion
 {
     VerifyReturnNil(imageData != nil);
     CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef) imageData, NULL);
@@ -774,16 +778,16 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
         return nil;
     }
 
-    return [self multipartRequestWithPath:path imageData:imageData metaData:metaData mediaContentType:mediaType];
+    return [self multipartRequestWithPath:path imageData:imageData metaData:metaData mediaContentType:mediaType apiVersion:apiVersion];
 }
 
-+ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSDictionary *)metaData mediaContentType:(NSString *)mediaContentType
++ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSDictionary *)metaData mediaContentType:(NSString *)mediaContentType apiVersion:(int)apiVersion
 {
     NSData *metaDataData = [NSJSONSerialization dataWithJSONObject:metaData options:0 error:NULL];
-    return [self multipartRequestWithPath:path imageData:imageData metaData:metaDataData metaDataContentType:@"application/json; charset=utf-8" mediaContentType:mediaContentType];
+    return [self multipartRequestWithPath:path imageData:imageData metaData:metaDataData metaDataContentType:@"application/json; charset=utf-8" mediaContentType:mediaContentType apiVersion:apiVersion];
 }
 
-+ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSData *)metaData metaDataContentType:(NSString *)metaDataContentType mediaContentType:(NSString *)mediaContentType;
++ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSData *)metaData metaDataContentType:(NSString *)metaDataContentType mediaContentType:(NSString *)mediaContentType apiVersion:(int)apiVersion;
 {
     VerifyReturnNil(imageData != nil);
     
@@ -799,7 +803,8 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
                                                      method:ZMMethodPOST
                                                  binaryData:multipartData
                                                        type:contentType
-                                         contentDisposition:nil];
+                                         contentDisposition:nil
+                                                 apiVersion:apiVersion];
     Require(result.hasRequiredPayload);
     return result;
 }

--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -524,6 +524,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 - (void)completeWithResponse:(ZMTransportResponse *)response
 {
+    RequireString(response.apiVersion == self.apiVersion, "Completed request and response should have matching api versions. Request has: %d Response has: %d", response.apiVersion, self.apiVersion);
     response.startOfUploadTimestamp = self.startOfUploadTimestamp;
 
     ZMSDispatchGroup *group = response.dispatchGroup;

--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -147,7 +147,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 @property (nonatomic) float progress;
 @property (nonatomic) NSMutableDictionary <NSString *, NSString *> *additionalHeaderFields;
 @property (nonatomic) BackgroundActivity *activity;
-@property (nonatomic) int apiVersion;
+@property (nonatomic) ZMAPIVersion apiVersion;
 
 @end
 
@@ -155,17 +155,17 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 @implementation ZMTransportRequest
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload apiVersion:(int)apiVersion
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload apiVersion:(ZMAPIVersion)apiVersion
 {
     return [self initWithPath:path method:method payload:payload authentication:ZMTransportRequestAuthNeedsAccess shouldCompress:NO apiVersion: apiVersion];
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress apiVersion:(ZMAPIVersion)apiVersion
 {
     return [self initWithPath:path method:method payload:payload authentication:ZMTransportRequestAuthNeedsAccess shouldCompress:shouldCompress apiVersion: apiVersion];
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication shouldCompress:(BOOL)shouldCompress apiVersion:(ZMAPIVersion)apiVersion;
 {
     self = [super init];
     if (self) {
@@ -185,35 +185,35 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     return self;
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication apiVersion:(int)apiVersion;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload authentication:(ZMTransportRequestAuth)authentication apiVersion:(ZMAPIVersion)apiVersion;
 {
     return [self initWithPath:path method:method payload:payload authentication:authentication shouldCompress:NO apiVersion:apiVersion];
 }
 
-+ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload apiVersion:(int)apiVersion
++ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload apiVersion:(ZMAPIVersion)apiVersion
 {
     return [[self class] requestWithPath:path method:method payload:payload shouldCompress:NO apiVersion:apiVersion];
 }
 
 
-+ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion
++ (instancetype)requestWithPath:(NSString *)path method:(ZMTransportRequestMethod)method payload:(id <ZMTransportData>)payload shouldCompress:(BOOL)shouldCompress apiVersion:(ZMAPIVersion)apiVersion
 {
     ZMTransportRequest *result = [[self alloc] initWithPath:path method:method payload:payload shouldCompress:shouldCompress apiVersion:apiVersion];
     Require(result.hasRequiredPayload);
     return result;
 }
 
-+ (instancetype)requestGetFromPath:(NSString *)path apiVersion:(int)apiVersion
++ (instancetype)requestGetFromPath:(NSString *)path apiVersion:(ZMAPIVersion)apiVersion
 {
     return [self requestWithPath:path method:ZMMethodGET payload:nil apiVersion:apiVersion];
 }
 
-+ (instancetype)compressedGetFromPath:(NSString *)path apiVersion:(int)apiVersion
++ (instancetype)compressedGetFromPath:(NSString *)path apiVersion:(ZMAPIVersion)apiVersion
 {
     return [self requestWithPath:path method:ZMMethodGET payload:nil shouldCompress:YES apiVersion:apiVersion];
 }
 
-+ (instancetype)uploadRequestWithFileURL:(NSURL *)url path:(NSString *)path contentType:(NSString *)contentType apiVersion:(int)apiVersion;
++ (instancetype)uploadRequestWithFileURL:(NSURL *)url path:(NSString *)path contentType:(NSString *)contentType apiVersion:(ZMAPIVersion)apiVersion;
 {
     ZMTransportRequest *request = [[self.class alloc] initWithPath:path
                                                             method:ZMMethodPOST
@@ -227,13 +227,13 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     return request;
 }
 
-+ (instancetype)emptyPutRequestWithPath:(NSString *)path apiVersion:(int)apiVersion;
++ (instancetype)emptyPutRequestWithPath:(NSString *)path apiVersion:(ZMAPIVersion)apiVersion;
 {
     NSString *type = (__bridge NSString *) kUTTypeJSON;
     return [[self alloc] initWithPath:path method:ZMMethodPUT binaryData:[NSData data] type:type contentDisposition:nil apiVersion:apiVersion];
 }
 
-+ (instancetype)imageGetRequestFromPath:(NSString *)path apiVersion:(int)apiVersion;
++ (instancetype)imageGetRequestFromPath:(NSString *)path apiVersion:(ZMAPIVersion)apiVersion;
 {
     ZMTransportRequest *r = [self requestGetFromPath:path apiVersion:apiVersion];
     r.acceptedResponseMediaTypes = ZMTransportAcceptImage;
@@ -241,12 +241,12 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     return r;
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(NSData *)data type:(NSString *)type contentDisposition:(NSDictionary *)contentDisposition apiVersion:(int)apiVersion;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(NSData *)data type:(NSString *)type contentDisposition:(NSDictionary *)contentDisposition apiVersion:(ZMAPIVersion)apiVersion;
 {
     return [self initWithPath:path method:method binaryData:data type:type contentDisposition:contentDisposition shouldCompress:NO apiVersion:apiVersion];
 }
 
-- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(NSData *)data type:(NSString *)type contentDisposition:(NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(NSData *)data type:(NSString *)type contentDisposition:(NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress apiVersion:(ZMAPIVersion)apiVersion;
 {
     self = [super init];
     if (self != nil) {
@@ -524,7 +524,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 - (void)completeWithResponse:(ZMTransportResponse *)response
 {
-    RequireString(response.apiVersion == self.apiVersion, "Completed request and response should have matching api versions. Request has: %d Response has: %d", response.apiVersion, self.apiVersion);
+    RequireString(response.apiVersion == self.apiVersion, "Completed request and response should have matching api versions. Request has: %d Response has: %ld", response.apiVersion, (long)self.apiVersion);
     response.startOfUploadTimestamp = self.startOfUploadTimestamp;
 
     ZMSDispatchGroup *group = response.dispatchGroup;
@@ -734,7 +734,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 @implementation ZMTransportRequest (AssetGet)
 
-+ (instancetype)assetGetRequestFromPath:(NSString *)path assetToken:(NSString *)token apiVersion:(int)apiVersion;
++ (instancetype)assetGetRequestFromPath:(NSString *)path assetToken:(NSString *)token apiVersion:(ZMAPIVersion)apiVersion;
 {
     ZMTransportRequest *r = [self requestGetFromPath:path apiVersion:apiVersion];
     
@@ -751,7 +751,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 @implementation ZMTransportRequest (ImageUpload)
 
-+ (instancetype)postRequestWithPath:(NSString *)path imageData:(NSData *)data contentDisposition:(NSDictionary *)contentDisposition apiVersion:(int)apiVersion;
++ (instancetype)postRequestWithPath:(NSString *)path imageData:(NSData *)data contentDisposition:(NSDictionary *)contentDisposition apiVersion:(ZMAPIVersion)apiVersion;
 {
     VerifyReturnNil(data != nil);
     CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef) data, NULL);
@@ -766,7 +766,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     return result;
 }
 
-+ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSDictionary *)metaData apiVersion:(int)apiVersion
++ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSDictionary *)metaData apiVersion:(ZMAPIVersion)apiVersion
 {
     VerifyReturnNil(imageData != nil);
     CGImageSourceRef source = CGImageSourceCreateWithData((__bridge CFDataRef) imageData, NULL);
@@ -782,13 +782,13 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
     return [self multipartRequestWithPath:path imageData:imageData metaData:metaData mediaContentType:mediaType apiVersion:apiVersion];
 }
 
-+ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSDictionary *)metaData mediaContentType:(NSString *)mediaContentType apiVersion:(int)apiVersion
++ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSDictionary *)metaData mediaContentType:(NSString *)mediaContentType apiVersion:(ZMAPIVersion)apiVersion
 {
     NSData *metaDataData = [NSJSONSerialization dataWithJSONObject:metaData options:0 error:NULL];
     return [self multipartRequestWithPath:path imageData:imageData metaData:metaDataData metaDataContentType:@"application/json; charset=utf-8" mediaContentType:mediaContentType apiVersion:apiVersion];
 }
 
-+ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSData *)metaData metaDataContentType:(NSString *)metaDataContentType mediaContentType:(NSString *)mediaContentType apiVersion:(int)apiVersion;
++ (instancetype)multipartRequestWithPath:(NSString *)path imageData:(NSData *)imageData metaData:(NSData *)metaData metaDataContentType:(NSString *)metaDataContentType mediaContentType:(NSString *)mediaContentType apiVersion:(ZMAPIVersion)apiVersion;
 {
     VerifyReturnNil(imageData != nil);
     

--- a/Source/Requests/ZMTransportResponse.m
+++ b/Source/Requests/ZMTransportResponse.m
@@ -45,25 +45,25 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 
 @implementation ZMTransportResponse
 
-- (instancetype)initWithHTTPURLResponse:(NSHTTPURLResponse *)HTTPResponse data:(NSData *)data error:(NSError *)error;
+- (instancetype)initWithHTTPURLResponse:(NSHTTPURLResponse *)HTTPResponse data:(NSData *)data error:(NSError *)error apiVersion:(int)apiVersion;
 {
     switch ([HTTPResponse zmContentTypeForBodyData:data]) {
         case ZMTransportResponseContentTypeImage: {
-            self = [self initWithImageData:data HTTPStatus:HTTPResponse.statusCode transportSessionError:error headers:HTTPResponse.allHeaderFields];
+            self = [self initWithImageData:data HTTPStatus:HTTPResponse.statusCode transportSessionError:error headers:HTTPResponse.allHeaderFields apiVersion:apiVersion];
             break;
         }
         case ZMTransportResponseContentTypeJSON: {
             id<ZMTransportData> responsePayload = [ZMTransportCodec interpretResponse:HTTPResponse data:data error:error];
-            self = [self initWithPayload:responsePayload HTTPStatus:HTTPResponse.statusCode transportSessionError:error headers:HTTPResponse.allHeaderFields];
+            self = [self initWithPayload:responsePayload HTTPStatus:HTTPResponse.statusCode transportSessionError:error headers:HTTPResponse.allHeaderFields apiVersion:apiVersion];
             break;
         }
         case ZMTransportResponseContentTypeEmpty: {
-            self = [self initWithPayload:nil HTTPStatus:HTTPResponse.statusCode transportSessionError:error headers:HTTPResponse.allHeaderFields];
+            self = [self initWithPayload:nil HTTPStatus:HTTPResponse.statusCode transportSessionError:error headers:HTTPResponse.allHeaderFields apiVersion:apiVersion];
             break;
         }
         default:
         {
-            self = [self initWithPayload:nil HTTPStatus:HTTPResponse.statusCode transportSessionError:error headers:HTTPResponse.allHeaderFields];
+            self = [self initWithPayload:nil HTTPStatus:HTTPResponse.statusCode transportSessionError:error headers:HTTPResponse.allHeaderFields apiVersion:apiVersion];
             self.rawData = data;
             break;
         }
@@ -73,13 +73,13 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
     return self;
 }
 
-- (instancetype)initWithImageData:(NSData *)imageData HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers;
+- (instancetype)initWithImageData:(NSData *)imageData HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(int)apiVersion;
 {
     return [self initWithImageData:imageData payload:nil HTTPStatus:status networkError:error headers:headers];
 }
 
 
-- (instancetype)initWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers;
+- (instancetype)initWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(int)apiVersion;
 {
     return [self initWithImageData:nil payload:payload HTTPStatus:status networkError:error headers:headers];
 }
@@ -101,19 +101,19 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
     return self;
 }
 
-+ (instancetype)responseWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers;
++ (instancetype)responseWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(int)apiVersion;
 {
-    return [[self alloc] initWithPayload:payload HTTPStatus:status transportSessionError:error headers:headers];
+    return [[self alloc] initWithPayload:payload HTTPStatus:status transportSessionError:error headers:headers apiVersion:apiVersion];
 }
 
-+ (instancetype)responseWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error;
++ (instancetype)responseWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error apiVersion:(int)apiVersion;
 {
-    return [self responseWithPayload:payload HTTPStatus:status transportSessionError:error headers:nil];
+    return [self responseWithPayload:payload HTTPStatus:status transportSessionError:error headers:nil apiVersion:apiVersion];
 }
 
-+ (instancetype)responseWithTransportSessionError:(NSError *)error;
++ (instancetype)responseWithTransportSessionError:(NSError *)error apiVersion:(int)apiVersion;
 {
-    return [self responseWithPayload:nil HTTPStatus:0 transportSessionError:error headers:nil];
+    return [self responseWithPayload:nil HTTPStatus:0 transportSessionError:error headers:nil apiVersion:apiVersion];
 }
 
 

--- a/Source/Requests/ZMTransportResponse.m
+++ b/Source/Requests/ZMTransportResponse.m
@@ -45,7 +45,7 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 
 @implementation ZMTransportResponse
 
-- (instancetype)initWithHTTPURLResponse:(NSHTTPURLResponse *)HTTPResponse data:(NSData *)data error:(NSError *)error apiVersion:(int)apiVersion;
+- (instancetype)initWithHTTPURLResponse:(NSHTTPURLResponse *)HTTPResponse data:(NSData *)data error:(NSError *)error apiVersion:(ZMAPIVersion)apiVersion;
 {
     switch ([HTTPResponse zmContentTypeForBodyData:data]) {
         case ZMTransportResponseContentTypeImage: {
@@ -73,13 +73,13 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
     return self;
 }
 
-- (instancetype)initWithImageData:(NSData *)imageData HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(int)apiVersion;
+- (instancetype)initWithImageData:(NSData *)imageData HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(ZMAPIVersion)apiVersion;
 {
     return [self initWithImageData:imageData payload:nil HTTPStatus:status networkError:error headers:headers];
 }
 
 
-- (instancetype)initWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(int)apiVersion;
+- (instancetype)initWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(ZMAPIVersion)apiVersion;
 {
     return [self initWithImageData:nil payload:payload HTTPStatus:status networkError:error headers:headers];
 }
@@ -101,17 +101,17 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
     return self;
 }
 
-+ (instancetype)responseWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(int)apiVersion;
++ (instancetype)responseWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(ZMAPIVersion)apiVersion;
 {
     return [[self alloc] initWithPayload:payload HTTPStatus:status transportSessionError:error headers:headers apiVersion:apiVersion];
 }
 
-+ (instancetype)responseWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error apiVersion:(int)apiVersion;
++ (instancetype)responseWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error apiVersion:(ZMAPIVersion)apiVersion;
 {
     return [self responseWithPayload:payload HTTPStatus:status transportSessionError:error headers:nil apiVersion:apiVersion];
 }
 
-+ (instancetype)responseWithTransportSessionError:(NSError *)error apiVersion:(int)apiVersion;
++ (instancetype)responseWithTransportSessionError:(NSError *)error apiVersion:(ZMAPIVersion)apiVersion;
 {
     return [self responseWithPayload:nil HTTPStatus:0 transportSessionError:error headers:nil apiVersion:apiVersion];
 }

--- a/Source/TransportSession/UnauthenticatedTransportSession.swift
+++ b/Source/TransportSession/UnauthenticatedTransportSession.swift
@@ -140,10 +140,10 @@ final public class UnauthenticatedTransportSession: NSObject, UnauthenticatedTra
             var transportResponse: ZMTransportResponse!
             
             if let response = response as? HTTPURLResponse {
-                transportResponse = ZMTransportResponse(httpurlResponse: response, data: data, error: error)
+                transportResponse = ZMTransportResponse(httpurlResponse: response, data: data, error: error, apiVersion: request.apiVersion)
             }
             else if let error = error {
-                transportResponse = ZMTransportResponse(transportSessionError: error)
+                transportResponse = ZMTransportResponse(transportSessionError: error, apiVersion: request.apiVersion)
             }
             
             if nil == transportResponse {

--- a/Source/TransportSession/ZMTransportSession.m
+++ b/Source/TransportSession/ZMTransportSession.m
@@ -548,7 +548,7 @@ static NSInteger const DefaultMaximumRequests = 6;
     [[NSNotificationCenter defaultCenter] postNotificationName:ZMTransportSessionNewRequestAvailableNotification object:self];
 }
 
-- (ZMTransportResponse *)transportResponseFromURLResponse:(NSURLResponse *)URLResponse data:(NSData *)data error:(NSError *)error apiVersion:(int)apiVersion;
+- (ZMTransportResponse *)transportResponseFromURLResponse:(NSURLResponse *)URLResponse data:(NSData *)data error:(NSError *)error apiVersion:(ZMAPIVersion)apiVersion;
 {
     NSHTTPURLResponse *HTTPResponse = (NSHTTPURLResponse *) URLResponse;
     return [[ZMTransportResponse alloc] initWithHTTPURLResponse:HTTPResponse data:data error:error apiVersion:apiVersion];

--- a/Source/URLSession/ZMURLSession.m
+++ b/Source/URLSession/ZMURLSession.m
@@ -453,7 +453,7 @@ totalBytesExpectedToSend:(int64_t)totalBytesExpectedToSend
     if (progress < request.progress) {
         float failureThresholdProgress = (float)totalBytes + ZMTransportDecreasedProgressCancellationLeeway / (float)totalBytesExpected;
         if (progress < failureThresholdProgress) {
-            [request completeWithResponse:[ZMTransportResponse responseWithTransportSessionError:NSError.tryAgainLaterError]];
+            [request completeWithResponse:[ZMTransportResponse responseWithTransportSessionError:NSError.tryAgainLaterError apiVersion:request.apiVersion]];
             return YES;
         }
     }

--- a/Tests/Source/Authentication/ZMAccessTokenHandlerTests.m
+++ b/Tests/Source/Authentication/ZMAccessTokenHandlerTests.m
@@ -305,7 +305,7 @@
     XCTAssertNotEqual(self.sut.currentAccessTokenTask, task);
     
     // when
-    BOOL didConsume = [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES];
+    BOOL didConsume = [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES apiVersion:0];
     
     // then
     XCTAssertFalse(didConsume);
@@ -320,7 +320,7 @@
     XCTAssertEqual(self.sut.currentAccessTokenTask, task);
     
     // when
-    BOOL didConsume = [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES];
+    BOOL didConsume = [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES apiVersion:0];
     
     // then
     XCTAssertTrue(didConsume);
@@ -337,7 +337,7 @@
     XCTAssertEqual(self.sut.currentAccessTokenTask, task);
     
     // when
-    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:NO];
+    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:NO apiVersion:0];
     
     // then
     XCTAssertNil(self.sut.currentAccessTokenTask);
@@ -353,7 +353,7 @@
 
     // when
     [self.sut sendAccessTokenRequestWithURLSession:self.urlSession];
-    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES];
+    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES apiVersion:0];
     
     // then
     XCTAssertNotNil(self.cookieStorage.authenticationCookieData);
@@ -370,14 +370,14 @@
     XCTAssertEqual(self.sut.currentAccessTokenTask, task1);
     
     // when consuming the request
-    [self.sut consumeRequestWithTask:task1 data:nil session:self.urlSession shouldRetry:YES];
+    [self.sut consumeRequestWithTask:task1 data:nil session:self.urlSession shouldRetry:YES apiVersion:0];
     
     // then we create a new task, because the first request failed
     XCTAssertEqual(self.backoff.increaseBackoffCount, 1);
     XCTAssertEqual(self.sut.currentAccessTokenTask, task2);
     
     // when consuming the second request
-    [self.sut consumeRequestWithTask:task2 data:nil session:self.urlSession shouldRetry:YES];
+    [self.sut consumeRequestWithTask:task2 data:nil session:self.urlSession shouldRetry:YES apiVersion:0];
     
     // then
     XCTAssertEqual(self.backoff.resetBackoffCount, 1);
@@ -393,7 +393,7 @@
     XCTAssertEqual(self.sut.currentAccessTokenTask, task1);
     
     // when consuming the request
-    [self.sut consumeRequestWithTask:task1 data:nil session:self.urlSession shouldRetry:NO];
+    [self.sut consumeRequestWithTask:task1 data:nil session:self.urlSession shouldRetry:NO apiVersion:0];
     
     // no new task is created
     XCTAssertNil(self.sut.currentAccessTokenTask);
@@ -419,7 +419,7 @@
     XCTAssertEqual(self.sut.currentAccessTokenTask, task);
     
     // when
-    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES];
+    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES apiVersion:0];
     
     // then
     XCTAssertEqual(self.backoff.increaseBackoffCount, 1);
@@ -436,7 +436,7 @@
     XCTAssertEqual(self.sut.currentAccessTokenTask, task);
     
     // when
-    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES];
+    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES apiVersion:0];
     
     // then
     XCTAssertEqual(self.backoff.increaseBackoffCount, 1);
@@ -453,7 +453,7 @@
     XCTAssertEqual(self.sut.currentAccessTokenTask, task);
     
     // when
-    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES];
+    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES apiVersion:0];
     
     // then
     XCTAssertEqual(self.backoff.increaseBackoffCount, 1);
@@ -472,7 +472,7 @@
     XCTAssertEqual(self.sut.currentAccessTokenTask, task);
     
     // when
-    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES];
+    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES apiVersion:0];
     
     // then
     XCTAssertEqual(self.backoff.increaseBackoffCount, 0);
@@ -489,7 +489,7 @@
     XCTAssertEqual(self.sut.currentAccessTokenTask, task);
     
     // when
-    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES];
+    [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:YES apiVersion:0];
     
     // then
     XCTAssertEqual(self.backoff.resetBackoffCount, 1);
@@ -846,7 +846,7 @@
     {
         id task  = [self mockURLSessionTaskWithStatusCode:500 error:nil hasTransportData:YES];
         [self.sut sendAccessTokenRequestWithURLSession:self.urlSession];
-        [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:NO];
+        [self.sut consumeRequestWithTask:task data:nil session:self.urlSession shouldRetry:NO apiVersion:0];
         XCTAssertNotNil(self.sut.accessToken);
     }
     

--- a/Tests/Source/Authentication/ZMTransportRequestLoggingTests.swift
+++ b/Tests/Source/Authentication/ZMTransportRequestLoggingTests.swift
@@ -38,7 +38,8 @@ final class ZMTransportRequestLoggingTests: ZMTBaseTest {
         //when
         let requestDescription = ZMTransportRequest(path: "/test",
                                                     method: .methodGET,
-                                                    payload: payload as ZMTransportData).description
+                                                    payload: payload as ZMTransportData,
+                                                    apiVersion: 0).description
         
         //then
         XCTAssertTrue(requestDescription.contains("password = \"<redacted>\""))

--- a/Tests/Source/Authentication/ZMTransportRequestLoggingTests.swift
+++ b/Tests/Source/Authentication/ZMTransportRequestLoggingTests.swift
@@ -39,7 +39,7 @@ final class ZMTransportRequestLoggingTests: ZMTBaseTest {
         let requestDescription = ZMTransportRequest(path: "/test",
                                                     method: .methodGET,
                                                     payload: payload as ZMTransportData,
-                                                    apiVersion: 0).description
+                                                    apiVersion: .v0).description
         
         //then
         XCTAssertTrue(requestDescription.contains("password = \"<redacted>\""))

--- a/Tests/Source/Requests/ZMTransportRequestTests.m
+++ b/Tests/Source/Requests/ZMTransportRequestTests.m
@@ -328,7 +328,7 @@
     ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     [transportRequest markStartOfUploadTimestamp];
     
-    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"name":@"foo"} HTTPStatus:213 transportSessionError:nil];
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"name":@"foo"} HTTPStatus:213 transportSessionError:nil apiVersion:transportRequest.apiVersion];
     
     // when
     [transportRequest completeWithResponse:response];
@@ -395,7 +395,7 @@
 {
     // given
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
-    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"name":@"foo"} HTTPStatus:213 transportSessionError:nil];
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"name":@"foo"} HTTPStatus:213 transportSessionError:nil apiVersion:0];
     __block ZMTransportResponse *receivedResponse;
     
     ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"" method:ZMMethodGET payload:nil apiVersion:0];
@@ -420,7 +420,7 @@
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"Completion 1 handler called"];
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"Completion 2 handler called"];
     XCTestExpectation *expectation3 = [self expectationWithDescription:@"Completion 3 handler called"];
-    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{} HTTPStatus:200 transportSessionError:nil];
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{} HTTPStatus:200 transportSessionError:nil apiVersion:0];
 
     __block NSMutableString *responses = [[NSMutableString alloc] init];
 

--- a/Tests/Source/Requests/ZMTransportRequestTests.m
+++ b/Tests/Source/Requests/ZMTransportRequestTests.m
@@ -52,46 +52,46 @@
 
 -(void)testThatNeedsAuthenticationIsSetByDefault;
 {
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{}].needsAuthentication);
-    XCTAssertTrue([ZMTransportRequest requestGetFromPath:@"/bar"].needsAuthentication);
-    XCTAssertTrue([ZMTransportRequest requestWithPath:@"/bar" method:ZMMethodPOST payload:@{}].needsAuthentication);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} apiVersion:0].needsAuthentication);
+    XCTAssertTrue([ZMTransportRequest requestGetFromPath:@"/bar" apiVersion:0].needsAuthentication);
+    XCTAssertTrue([ZMTransportRequest requestWithPath:@"/bar" method:ZMMethodPOST payload:@{} apiVersion:0].needsAuthentication);
 }
 
 -(void)testThatCreatesAccessTokenIsNotSetByDefault;
 {
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{}].responseWillContainAccessToken);
-    XCTAssertFalse([ZMTransportRequest requestGetFromPath:@"/bar"].responseWillContainAccessToken);
-    XCTAssertFalse([ZMTransportRequest requestWithPath:@"/bar" method:ZMMethodPOST payload:@{}].responseWillContainAccessToken);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} apiVersion:0].responseWillContainAccessToken);
+    XCTAssertFalse([ZMTransportRequest requestGetFromPath:@"/bar" apiVersion:0].responseWillContainAccessToken);
+    XCTAssertFalse([ZMTransportRequest requestWithPath:@"/bar" method:ZMMethodPOST payload:@{} apiVersion:0].responseWillContainAccessToken);
 }
 
 - (void)testThatNeedsAuthenticationIsSet
 {
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone].needsAuthentication);
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken].needsAuthentication);
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess].needsAuthentication);
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsCookieAndAccessToken].needsAuthentication);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].needsAuthentication);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].needsAuthentication);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].needsAuthentication);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsCookieAndAccessToken apiVersion:0].needsAuthentication);
 }
 
 - (void)testThatNeedsCookieIsSet
 {
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone].needsCookie);
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken].needsCookie);
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess].needsCookie);
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsCookieAndAccessToken].needsCookie);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].needsCookie);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].needsCookie);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].needsCookie);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsCookieAndAccessToken apiVersion:0].needsCookie);
 }
 
 - (void)testThatCreatesAccessTokenIsSet
 {
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone].responseWillContainAccessToken);
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken].responseWillContainAccessToken);
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess].responseWillContainAccessToken);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].responseWillContainAccessToken);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].responseWillContainAccessToken);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].responseWillContainAccessToken);
 }
 
 - (void)testThatResponseWillContainCookieIsSet;
 {
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone].responseWillContainCookie);
-    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken].responseWillContainCookie);
-    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess].responseWillContainCookie);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNone apiVersion:0].responseWillContainCookie);
+    XCTAssertTrue([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0].responseWillContainCookie);
+    XCTAssertFalse([[ZMTransportRequest alloc] initWithPath:@"/bar" method:ZMMethodPOST payload:@{} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0].responseWillContainCookie);
 }
 
 -(void)testThatRequestGetFromPathSetsProperties
@@ -101,7 +101,7 @@
     NSMutableString *path = [NSMutableString stringWithString:originalPath];
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:path];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:path apiVersion:0];
     [path setString:@"baz"]; // test that it is copied
     
     // then
@@ -121,7 +121,7 @@
     NSDictionary * const disposition = @{@"zasset": [NSNull null], @"conv_id": [NSUUID createUUID].transportString};
     
     // when
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:path method:method binaryData:data type:(__bridge id) kUTTypePNG contentDisposition:disposition];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:path method:method binaryData:data type:(__bridge id) kUTTypePNG contentDisposition:disposition apiVersion:0];
     
     // then
     XCTAssertNotNil(request);
@@ -142,7 +142,7 @@
     
     // when
     NSString *contentType = @"multipart/mixed; boundary=frontier";
-    ZMTransportRequest *request = [ZMTransportRequest uploadRequestWithFileURL:fileURL path:path contentType:contentType];
+    ZMTransportRequest *request = [ZMTransportRequest uploadRequestWithFileURL:fileURL path:path contentType:contentType apiVersion:0];
     
     // then
     XCTAssertNotNil(request);
@@ -163,7 +163,7 @@
     ZMTransportRequestMethod const method = ZMMethodPUT;
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest emptyPutRequestWithPath:path];
+    ZMTransportRequest *request = [ZMTransportRequest emptyPutRequestWithPath:path apiVersion:0];
     NSMutableURLRequest *httpRequest = [[NSMutableURLRequest alloc] init];
     [request setBodyDataAndMediaTypeOnHTTPRequest:httpRequest];
     
@@ -188,7 +188,7 @@
     NSDictionary * const disposition = @{@"zasset": [NSNull null], @"conv_id": [NSUUID createUUID].transportString};
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest postRequestWithPath:path imageData:data contentDisposition:disposition];
+    ZMTransportRequest *request = [ZMTransportRequest postRequestWithPath:path imageData:data contentDisposition:disposition apiVersion:0];
     
     // then
     XCTAssertNotNil(request);
@@ -208,7 +208,7 @@
     XCTAssertNotNil(textData);
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest postRequestWithPath:@"/some/path" imageData:textData contentDisposition:@{}];
+    ZMTransportRequest *request = [ZMTransportRequest postRequestWithPath:@"/some/path" imageData:textData contentDisposition:@{} apiVersion:0];
     
     // then
     XCTAssertNil(request);
@@ -225,7 +225,7 @@
     NSData *metaDataData = [NSJSONSerialization dataWithJSONObject:disposition options:0 error:NULL];
 
     // when
-    ZMTransportRequest *request = [ZMTransportRequest multipartRequestWithPath:path imageData:data metaData:disposition];
+    ZMTransportRequest *request = [ZMTransportRequest multipartRequestWithPath:path imageData:data metaData:disposition apiVersion:0];
     
     // then
     XCTAssertNotNil(request);
@@ -257,7 +257,7 @@
     XCTAssertNotNil(textData);
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest multipartRequestWithPath:@"/some/path" imageData:textData metaData:@{}];
+    ZMTransportRequest *request = [ZMTransportRequest multipartRequestWithPath:@"/some/path" imageData:textData metaData:@{} apiVersion:0];
     
     // then
     XCTAssertNil(request);
@@ -267,7 +267,7 @@
 {
     // given
     XCTestExpectation *expectation = [self expectationWithDescription:@"Task created handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     ZMTaskIdentifier *expectedIdentifier = [ZMTaskIdentifier identifierWithIdentifier:2 sessionIdentifier:@"test-session"];
     
     ZMTaskCreatedHandler *handler = [ZMTaskCreatedHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTaskIdentifier *identifier) {
@@ -290,7 +290,7 @@
     XCTestExpectation *firstExpectation = [self expectationWithDescription:@"First task created handler called"];
     XCTestExpectation *secondExpectation = [self expectationWithDescription:@"Second task created handler called"];;
     
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     ZMTaskIdentifier *expectedIdentifier = [ZMTaskIdentifier identifierWithIdentifier:2 sessionIdentifier:@"test-session"];
     
     ZMTaskCreatedHandler *firstHandler = [ZMTaskCreatedHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTaskIdentifier *identifier) {
@@ -316,7 +316,7 @@
 - (void)testThatItDoesNotAttemptToCallATaskCreatedHandlerIfNoneIsSet
 {
     // given
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     
     // when
     XCTAssertNoThrow([transportRequest callTaskCreationHandlersWithIdentifier:0 sessionIdentifier:@""]);
@@ -325,7 +325,7 @@
 - (void)testThatItSetsStartOfUploadTimestamp
 {
     // given
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     [transportRequest markStartOfUploadTimestamp];
     
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"name":@"foo"} HTTPStatus:213 transportSessionError:nil];
@@ -341,7 +341,7 @@
 {
     // given
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
 
     [transportRequest addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED){
@@ -361,7 +361,7 @@
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"Completion 1 handler called"];
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"Completion 2 handler called"];
 
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     
     [transportRequest addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED){
@@ -384,7 +384,7 @@
 - (void)testThatItDoesNotAttemptToCallACompletionHandlerIfNoneIsSet
 {
     // given
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
 
     // when
     XCTAssertNoThrow([transportRequest completeWithResponse:[[ZMTransportResponse alloc] init]]);
@@ -398,7 +398,7 @@
     ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@{@"name":@"foo"} HTTPStatus:213 transportSessionError:nil];
     __block ZMTransportResponse *receivedResponse;
     
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"" method:ZMMethodGET payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"" method:ZMMethodGET payload:nil apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *actualResponse){
         receivedResponse = actualResponse;
@@ -425,7 +425,7 @@
     __block NSMutableString *responses = [[NSMutableString alloc] init];
 
 
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"" method:ZMMethodGET payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"" method:ZMMethodGET payload:nil apiVersion:0];
 
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *resp) {
         NOT_USED(resp);
@@ -460,7 +460,7 @@
     const float expectedProgress = 0.5f;
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
         XCTAssertEqual(expectedProgress, progress);
@@ -481,7 +481,7 @@
     const static size_t expectedProgressSize = sizeof(expectedProgress) / sizeof(expectedProgress[0]);
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     
     NSUInteger __block currentCallIndex = 0;
     
@@ -510,7 +510,7 @@
     const float expectedProgress = 1.0f;
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
         XCTAssertEqual(expectedProgress, progress);
@@ -531,7 +531,7 @@
     const float expectedProgress = 0.0f;
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"Task progress handler called"];
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
         XCTAssertEqual(expectedProgress, progress);
@@ -553,7 +553,7 @@
     XCTestExpectation *expectation1 = [self expectationWithDescription:@"Task progress handler 1 called"];
     XCTestExpectation *expectation2 = [self expectationWithDescription:@"Task progress handler 2 called"];
 
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     
     [transportRequest addProgressHandler: [ZMTaskProgressHandler handlerOnGroupQueue:self.fakeSyncContext block:^(float progress) {
         XCTAssertEqual(expectedProgress, progress);
@@ -575,7 +575,7 @@
 - (void)testThatItDoesNotAttemptToCallATaskProgressHandlerIfNoneIsSet
 {
     // given
-    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{}];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest requestWithPath:@"/something" method:ZMMethodPUT payload:@{} apiVersion:0];
     
     // when
     XCTAssertNoThrow([transportRequest updateProgress:1.0f]);
@@ -585,7 +585,7 @@
 - (void)testThatARequestShouldBeExecutedOnlyOnForegroundSessionByDefault
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"Foo"];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"Foo" apiVersion:0];
     
     // then
     XCTAssertFalse(request.shouldUseOnlyBackgroundSession);
@@ -595,7 +595,7 @@
 - (void)testThatARequestShouldUseOnlyBackgroundSessionWhenForced
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"Foo"];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"Foo" apiVersion:0];
 
     // when
     [request forceToBackgroundSession];
@@ -608,7 +608,7 @@
 - (void)testThatARequestShouldUseOnlyVoipSessionWhenForced
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"Foo"];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"Foo" apiVersion:0];
     
     // when
     [request forceToVoipSession];
@@ -629,7 +629,7 @@
 - (void)testThatItSetsAcceptsImageData;
 {
     // given
-    ZMTransportRequest *sut = [ZMTransportRequest imageGetRequestFromPath:@"/foo/bar"];
+    ZMTransportRequest *sut = [ZMTransportRequest imageGetRequestFromPath:@"/foo/bar" apiVersion:0];
     
     // then
     XCTAssertEqual(sut.acceptedResponseMediaTypes, ZMTransportAcceptImage);
@@ -638,25 +638,25 @@
 - (void)testThatItSetsAcceptsTransportData;
 {
     // (1) given
-    ZMTransportRequest *sut = [ZMTransportRequest requestGetFromPath:@"/foo/bar"];
+    ZMTransportRequest *sut = [ZMTransportRequest requestGetFromPath:@"/foo/bar" apiVersion:0];
     
     // then
     XCTAssertEqual(sut.acceptedResponseMediaTypes, ZMTransportAcceptTransportData);
     
     // (2) given
-    sut = [ZMTransportRequest requestWithPath:@"/foo2" method:ZMMethodPOST payload:@{@"f": @2}];
+    sut = [ZMTransportRequest requestWithPath:@"/foo2" method:ZMMethodPOST payload:@{@"f": @2} apiVersion:0];
     
     // then
     XCTAssertEqual(sut.acceptedResponseMediaTypes, ZMTransportAcceptTransportData);
 
     // (3) given
-    sut = [[ZMTransportRequest alloc] initWithPath:@"/hello" method:ZMMethodPUT binaryData:[@"asdf" dataUsingEncoding:NSUTF8StringEncoding] type:@"image/jpeg" contentDisposition:@{@"asdf": @42}];
+    sut = [[ZMTransportRequest alloc] initWithPath:@"/hello" method:ZMMethodPUT binaryData:[@"asdf" dataUsingEncoding:NSUTF8StringEncoding] type:@"image/jpeg" contentDisposition:@{@"asdf": @42} apiVersion:0];
     
     // then
     XCTAssertEqual(sut.acceptedResponseMediaTypes, ZMTransportAcceptTransportData);
 
     // (4) given
-    sut = [[ZMTransportRequest alloc] initWithPath:@"/hello" method:ZMMethodPUT payload:@{@"A": @3} authentication:ZMTransportRequestAuthNeedsAccess];
+    sut = [[ZMTransportRequest alloc] initWithPath:@"/hello" method:ZMMethodPUT payload:@{@"A": @3} authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0];
 
     // then
     XCTAssertEqual(sut.acceptedResponseMediaTypes, ZMTransportAcceptTransportData);
@@ -672,7 +672,7 @@
 {
     // given
     NSDictionary *payload = @{@"A": @2};
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST payload:payload];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST payload:payload apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -687,7 +687,7 @@
 
 - (void)testThatItSetsAdditionalHeaderFieldsOnURLRequest;
 {
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodGET payload:nil];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodGET payload:nil apiVersion:0];
     [sut addValue:@"as73e8f98a7==" forAdditionalHeaderField:@"Access-Token"];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
 
@@ -702,7 +702,7 @@
 {
     // given
     NSString *token = @"NzFoNzJoZDYyMTI=";
-    ZMTransportRequest *sut = [ZMTransportRequest assetGetRequestFromPath:@"/assets/v3" assetToken:token];
+    ZMTransportRequest *sut = [ZMTransportRequest assetGetRequestFromPath:@"/assets/v3" assetToken:token apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -715,7 +715,7 @@
 - (void)testThatAssetGetRequestDoesNotSetAccessTokenIfNotPresent;
 {
     // given
-    ZMTransportRequest *sut = [ZMTransportRequest assetGetRequestFromPath:@"/assets/v3" assetToken:nil];
+    ZMTransportRequest *sut = [ZMTransportRequest assetGetRequestFromPath:@"/assets/v3" assetToken:nil apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -738,7 +738,7 @@
         [payload addObject:a];
     }
     // The encoded transport data is approximately 46k bytes.
-    ZMTransportRequest *sut = [ZMTransportRequest requestWithPath:@"/foo" method:ZMMethodPOST payload:payload shouldCompress:YES];
+    ZMTransportRequest *sut = [ZMTransportRequest requestWithPath:@"/foo" method:ZMMethodPOST payload:payload shouldCompress:YES apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     NSString *expected = @"H4sIAAAAAAAAE4XaS08qWRhG4f/C1DMoLlVQJzkD+yjeFRCvn"
     @"R5wEwUUBRS10/+9k056sNdgffM9eJLlpeqt/effldFgNa78zH5UxoPNoPKzMpwUeWc2and"
@@ -779,7 +779,7 @@
 {
     // given
     NSData *data = [@"jhasdhjkadshjklad" dataUsingEncoding:NSUTF8StringEncoding];
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST binaryData:data type:(__bridge NSString *) kUTTypeJPEG contentDisposition:nil];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST binaryData:data type:(__bridge NSString *) kUTTypeJPEG contentDisposition:nil apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -793,7 +793,7 @@
 - (void)testThatItDoesNotSetMediaTypeForRequestWithoutPayload;
 {
     // given
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodGET payload:nil];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodGET payload:nil apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -811,7 +811,8 @@
     NSURL *fileURL = [NSURL URLWithString:@"file://url/to/file"];
     ZMTransportRequest *sut = [ZMTransportRequest uploadRequestWithFileURL:fileURL
                                                                       path:[[NSBundle mainBundle] bundlePath]
-                                                               contentType:contentType];
+                                                               contentType:contentType
+                                                                apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -827,7 +828,7 @@
     // given
     NSData *data = [@"jhasdhjkadshjklad" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *disposition = @{@"A": @YES, @"b": @1, @"c": @"foo bar", @"d": @"z", @"e": [NSNull null]};
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST binaryData:data type:(__bridge NSString *) kUTTypeJPEG contentDisposition:disposition];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST binaryData:data type:(__bridge NSString *) kUTTypeJPEG contentDisposition:disposition apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -841,7 +842,7 @@
 {
     // given
     NSData *data = [@"jhasdhjkadshjklad" dataUsingEncoding:NSUTF8StringEncoding];
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST binaryData:data type:(__bridge NSString *) kUTTypeJPEG contentDisposition:nil];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST binaryData:data type:(__bridge NSString *) kUTTypeJPEG contentDisposition:nil apiVersion:0];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
     
     // when
@@ -854,7 +855,7 @@
 - (void)testThatItSetsAnExpirationDate;
 {
     // given
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodGET payload:nil];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodGET payload:nil apiVersion:0];
     NSTimeInterval interval = 35;
     
     // when
@@ -877,7 +878,7 @@
 - (void)testThatPOSTWithPayloadHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodPOST payload:@{}];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodPOST payload:@{} apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -886,7 +887,7 @@
 - (void)testThatPOSTWithNoPayloadHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodPOST payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodPOST payload:nil apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -895,7 +896,7 @@
 - (void)testThatDELETEWithPayloadHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMMethodDELETE payload:@{}];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMMethodDELETE payload:@{} apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -904,7 +905,7 @@
 - (void)testThatDELETEWithNoPayloadHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMMethodDELETE payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMMethodDELETE payload:nil apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -913,7 +914,7 @@
 - (void)testThatGETWithoutPayloadHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMMethodGET payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"Foo" method:ZMMethodGET payload:nil apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -922,7 +923,7 @@
 - (void)testThatHEADHasRequiredPayload
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil apiVersion:0];
     
     // then
     XCTAssertTrue(request.hasRequiredPayload);
@@ -958,7 +959,7 @@
                       usingBackgroundSession:(BOOL)usingBackgroundSession
 {
     // given
-    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST payload:nil];
+    ZMTransportRequest *sut = [[ZMTransportRequest alloc] initWithPath:@"/foo" method:ZMMethodPOST payload:nil apiVersion:0];
     if (usingBackgroundSession) {
         [sut forceToBackgroundSession];
     }
@@ -986,7 +987,7 @@
     // given
     NSString *info1 = @"....xxxXXXxxx....";
     NSString *info2 = @"32432525245345435";
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil apiVersion:0];
     
     // when
     [request addContentDebugInformation:info1];
@@ -1002,7 +1003,7 @@
 - (void)testPrivateDescription
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:@"foo" method:ZMMethodHEAD payload:nil apiVersion:0];
     
     // when
     NSString *privateDescription = [request safeForLoggingDescription];
@@ -1018,7 +1019,7 @@
     NSString *clientID = @"608b4f25ba2b193";
     NSString *uuid = @"9e86b08a-8de7-11e9-810f-22000a62954d";
     NSString *path = [NSString stringWithFormat:@"do/something/%@/useful?client=%@", uuid, clientID];
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
     
     // when
     NSString *privateDescription = [request safeForLoggingDescription];
@@ -1036,7 +1037,7 @@
     NSString *clientID = @"608b4f25ba2b193";
     NSString *uuid = @"9e86b08a-8de7-11e9-810f-22000a62954d";
     NSString *path = [NSString stringWithFormat:@"with/%@/🤨/%@/emoji", clientID, uuid];
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
 
     // when
     NSString *privateDescription = [request safeForLoggingDescription];
@@ -1055,7 +1056,7 @@
     NSString *clientID = @"608b4f25ba2b193";
     NSString *uuid = @"9e86b08a-8de7-11e9-810f-22000a62954d";
     NSString *path = [NSString stringWithFormat:@"ids/%@%@/overlapped", clientID, uuid];
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
 
     // when
     NSString *privateDescription = [request safeForLoggingDescription];
@@ -1068,7 +1069,7 @@
 
     // given
     path = [NSString stringWithFormat:@"ids/%@%@/overlapped", uuid, clientID];
-    request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil];
+    request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
 
     // when
     privateDescription = [request safeForLoggingDescription];
@@ -1081,7 +1082,7 @@
 
     // given
     path = [NSString stringWithFormat:@"ids/%@%@/overlapped", uuid, uuid];
-    request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil];
+    request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
 
     // when
     privateDescription = [request safeForLoggingDescription];
@@ -1093,7 +1094,7 @@
 
     // given
     path = [NSString stringWithFormat:@"ids/%@%@/overlapped", clientID, clientID];
-    request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil];
+    request = [ZMTransportRequest requestWithPath:path method:ZMMethodHEAD payload:nil apiVersion:0];
 
     // when
     privateDescription = [request safeForLoggingDescription];

--- a/Tests/Source/Requests/ZMTransportResponseTests.m
+++ b/Tests/Source/Requests/ZMTransportResponseTests.m
@@ -32,15 +32,15 @@
 - (void)testThatItReturnFailureOnHTTPError
 {
     [self performIgnoringZMLogError:^{
-        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:0 transportSessionError:nil];
+        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:0 transportSessionError:nil apiVersion:0];
         XCTAssertNotEqual(response.result, ZMTransportResponseStatusSuccess);
     }];
     for(int status = 1; status < 99; ++status) {
-        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:status transportSessionError:nil];
+        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:status transportSessionError:nil apiVersion:0];
         XCTAssertNotEqual(response.result, ZMTransportResponseStatusSuccess);
     }
     for(int status = 300; status < 999; ++status) {
-        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:status transportSessionError:nil];
+        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:status transportSessionError:nil apiVersion:0];
         XCTAssertNotEqual(response.result, ZMTransportResponseStatusSuccess);
     }
 }
@@ -49,7 +49,7 @@
 {
     [self performIgnoringZMLogError:^{
         NSError *error = [NSError errorWithDomain:@"foo" code:123 userInfo:nil];
-        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:200 transportSessionError:error];
+        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:200 transportSessionError:error apiVersion:0];
         XCTAssertNotEqual(response.result, ZMTransportResponseStatusSuccess);
     }];
 }
@@ -59,7 +59,7 @@
     [self performIgnoringZMLogError:^{
         NSArray<NSNumber *> * permanentErrors = @[@(400), @(403), @(404), @(405), @(406), @(410), @(412), @(451)];
         for (NSNumber *code in permanentErrors) {
-            ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:code.integerValue transportSessionError:nil];
+            ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:code.integerValue transportSessionError:nil apiVersion:0];
             XCTAssertTrue(response.isPermanentylUnavailableError);
         }
     }];
@@ -70,7 +70,7 @@
     [self performIgnoringZMLogError:^{
         NSArray<NSNumber *> * permanentErrors = @[@(401), @(500), @(201), @(302)];
         for (NSNumber *code in permanentErrors) {
-            ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:code.integerValue transportSessionError:nil];
+            ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:code.integerValue transportSessionError:nil apiVersion:0];
             XCTAssertFalse(response.isPermanentylUnavailableError);
         }
     }];
@@ -79,7 +79,7 @@
 - (void)testThatItReturnsNoPermanentErrorForSuccess
 {
     for(int status = 200; status < 300; ++status) {
-        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:status transportSessionError:nil];
+        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:status transportSessionError:nil apiVersion:0];
         XCTAssertFalse(response.isPermanentylUnavailableError);
     }
 }
@@ -87,7 +87,7 @@
 - (void)testThatItReturnSuccess
 {
     for(int status = 200; status < 300; ++status) {
-        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:status transportSessionError:nil];
+        ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:@[] HTTPStatus:status transportSessionError:nil apiVersion:0];
         XCTAssertEqual(response.result, ZMTransportResponseStatusSuccess);
     }
 }
@@ -95,7 +95,7 @@
 - (void)testThatItReturnsATimeout
 {
     NSError *error = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeRequestExpired userInfo:nil];
-    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:nil HTTPStatus:0 transportSessionError:error];
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:nil HTTPStatus:0 transportSessionError:error apiVersion:0];
     XCTAssertEqual(response.result, ZMTransportResponseStatusExpired);
 }
 
@@ -105,7 +105,7 @@
     NSInteger statusCode = 432;
     NSError *error = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeTryAgainLater userInfo:@{@"errortest": @"foo-bar"}];
     
-    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:payload HTTPStatus:statusCode transportSessionError:error];
+    ZMTransportResponse *response = [ZMTransportResponse responseWithPayload:payload HTTPStatus:statusCode transportSessionError:error apiVersion:0];
     
     XCTAssertNil(response.imageData);
     XCTAssertEqualObjects(response.payload, payload);
@@ -119,7 +119,7 @@
     NSInteger statusCode = 432;
     NSError *error = [NSError errorWithDomain:ZMTransportSessionErrorDomain code:ZMTransportSessionErrorCodeRequestExpired userInfo:@{@"errortest": @"foo-bar"}];
     
-    ZMTransportResponse *response = [[ZMTransportResponse alloc ] initWithImageData:imageData HTTPStatus:statusCode transportSessionError:error headers:nil];
+    ZMTransportResponse *response = [[ZMTransportResponse alloc ] initWithImageData:imageData HTTPStatus:statusCode transportSessionError:error headers:nil apiVersion:0];
     
     XCTAssertNil(response.payload);
     XCTAssertEqualObjects(response.imageData, imageData);
@@ -130,8 +130,8 @@
 - (void)testThatAnHTTPErrorLowerThan500DoesNotSetsAnError
 {
     for(NSInteger i = 100; i < 500; ++i) {
-        ZMTransportResponse *imageResponse = [[ZMTransportResponse alloc] initWithImageData:[NSData data] HTTPStatus:i transportSessionError:nil headers:nil];
-        ZMTransportResponse *payloadResponse = [[ZMTransportResponse alloc] initWithPayload:@{} HTTPStatus:i transportSessionError:nil headers:nil];
+        ZMTransportResponse *imageResponse = [[ZMTransportResponse alloc] initWithImageData:[NSData data] HTTPStatus:i transportSessionError:nil headers:nil apiVersion:0];
+        ZMTransportResponse *payloadResponse = [[ZMTransportResponse alloc] initWithPayload:@{} HTTPStatus:i transportSessionError:nil headers:nil apiVersion:0];
         XCTAssertNil(imageResponse.transportSessionError);
         XCTAssertNil(payloadResponse.transportSessionError);
         XCTAssertNotEqual(imageResponse.result, ZMTransportResponseStatusTemporaryError);
@@ -145,8 +145,8 @@
         if(i == 408) { // 408 is a timeout
             continue;
         }
-        ZMTransportResponse *imageResponse = [[ZMTransportResponse alloc] initWithImageData:[NSData data] HTTPStatus:i transportSessionError:nil headers:nil];
-        ZMTransportResponse *payloadResponse = [[ZMTransportResponse alloc] initWithPayload:@{} HTTPStatus:i transportSessionError:nil headers:nil];
+        ZMTransportResponse *imageResponse = [[ZMTransportResponse alloc] initWithImageData:[NSData data] HTTPStatus:i transportSessionError:nil headers:nil apiVersion:0];
+        ZMTransportResponse *payloadResponse = [[ZMTransportResponse alloc] initWithPayload:@{} HTTPStatus:i transportSessionError:nil headers:nil apiVersion:0];
         XCTAssertEqual(imageResponse.result, ZMTransportResponseStatusPermanentError);
         XCTAssertEqual(payloadResponse.result, ZMTransportResponseStatusPermanentError);
     }
@@ -154,8 +154,8 @@
 
 - (void)testThatAnHTTPErrorOf408IsATryAgainLater
 {
-    ZMTransportResponse *imageResponse = [[ZMTransportResponse alloc] initWithImageData:[NSData data] HTTPStatus:408 transportSessionError:nil headers:nil];
-    ZMTransportResponse *payloadResponse = [[ZMTransportResponse alloc] initWithPayload:@{} HTTPStatus:408 transportSessionError:nil headers:nil];
+    ZMTransportResponse *imageResponse = [[ZMTransportResponse alloc] initWithImageData:[NSData data] HTTPStatus:408 transportSessionError:nil headers:nil apiVersion:0];
+    ZMTransportResponse *payloadResponse = [[ZMTransportResponse alloc] initWithPayload:@{} HTTPStatus:408 transportSessionError:nil headers:nil apiVersion:0];
     XCTAssertEqual(imageResponse.result, ZMTransportResponseStatusTryAgainLater);
     XCTAssertEqual(payloadResponse.result, ZMTransportResponseStatusTryAgainLater);
 }
@@ -166,8 +166,8 @@
         if(i >= 300 && i < 500) {
             continue;
         }
-        ZMTransportResponse *imageResponse = [[ZMTransportResponse alloc] initWithImageData:[NSData data] HTTPStatus:i transportSessionError:nil headers:nil];
-        ZMTransportResponse *payloadResponse = [[ZMTransportResponse alloc] initWithPayload:@{} HTTPStatus:i transportSessionError:nil headers:nil];
+        ZMTransportResponse *imageResponse = [[ZMTransportResponse alloc] initWithImageData:[NSData data] HTTPStatus:i transportSessionError:nil headers:nil apiVersion:0];
+        ZMTransportResponse *payloadResponse = [[ZMTransportResponse alloc] initWithPayload:@{} HTTPStatus:i transportSessionError:nil headers:nil apiVersion:0];
         XCTAssertNotEqual(imageResponse.result, ZMTransportResponseStatusPermanentError);
         XCTAssertNotEqual(payloadResponse.result, ZMTransportResponseStatusPermanentError);
     }
@@ -184,7 +184,7 @@
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headerFields];
     
     // when
-    ZMTransportResponse *sut = [[ZMTransportResponse alloc] initWithHTTPURLResponse:response data:[NSData data] error:nil];
+    ZMTransportResponse *sut = [[ZMTransportResponse alloc] initWithHTTPURLResponse:response data:[NSData data] error:nil apiVersion:0];
     
     // then
     XCTAssertNotNil(sut);
@@ -205,7 +205,7 @@
     
     // when
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headerFields];
-    ZMTransportResponse *zmResponse = [[ZMTransportResponse alloc] initWithHTTPURLResponse:response data:contentData error:nil];
+    ZMTransportResponse *zmResponse = [[ZMTransportResponse alloc] initWithHTTPURLResponse:response data:contentData error:nil apiVersion:0];
     
     // then
     XCTAssertNotNil(zmResponse);
@@ -257,7 +257,7 @@
     
     // when
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:URL statusCode:200 HTTPVersion:@"HTTP/1.1" headerFields:headerFields];
-    ZMTransportResponse *zmResponse = [[ZMTransportResponse alloc] initWithHTTPURLResponse:response data:nil error:nil];
+    ZMTransportResponse *zmResponse = [[ZMTransportResponse alloc] initWithHTTPURLResponse:response data:nil error:nil apiVersion:0];
     
     // then
     XCTAssertEqual([response zmContentTypeForBodyData:[NSData data]], ZMTransportResponseContentTypeEmpty);

--- a/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -108,25 +108,25 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
     func testThatEnqueueOneTime_IncrementsTheRequestCounter() {
         // when
         (0..<3).forEach { _ in
-            sut.enqueueOneTime(.init(getFromPath: "/"))
+            sut.enqueueOneTime(.init(getFromPath: "/", apiVersion: 0))
         }
         
         // then
-        let result = sut.enqueueRequest { .init(getFromPath: "/") }
+        let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
         XCTAssertEqual(result, .maximumNumberOfRequests)
     }
     
     func testThatEnqueueOneTime_IsNotLimitedByRequestLimit() {
         // given
         (0..<3).forEach { _ in
-            sut.enqueueOneTime(.init(getFromPath: "/"))
+            sut.enqueueOneTime(.init(getFromPath: "/", apiVersion: 0))
         }
         
         let task = MockTask()
         sessionMock.nextMockTask = task
         
         // when
-        sut.enqueueOneTime(.init(getFromPath: "/"))
+        sut.enqueueOneTime(.init(getFromPath: "/", apiVersion: 0))
         
         // then
         XCTAssertEqual(task.resumeCallCount, 1)
@@ -138,7 +138,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         sessionMock.nextMockTask = task
 
         // when
-        let result = sut.enqueueRequest { .init(getFromPath: "/") }
+        let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
 
         // then
         XCTAssertEqual(result, .success)
@@ -156,19 +156,19 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
     func testThatItDoesNotEnqueueMoreThanThreeRequests() {
         // when
         (0..<3).forEach { _ in
-            let result = sut.enqueueRequest { .init(getFromPath: "/") }
+            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
             XCTAssertEqual(result, .success)
         }
 
         // then
-        let result = sut.enqueueRequest { .init(getFromPath: "/") }
+        let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
         XCTAssertEqual(result, .maximumNumberOfRequests)
     }
 
     func testThatItDoesEnqueueAnotherRequestAfterTheLastOneHasBeenCompleted() {
         // when
         (0..<3).forEach { _ in
-            let result = sut.enqueueRequest { .init(getFromPath: "/") }
+            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
             XCTAssertEqual(result, .success)
         }
 
@@ -176,7 +176,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
 
         // then
         do {
-            let result = sut.enqueueRequest { .init(getFromPath: "/") }
+            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
             XCTAssertEqual(result, .maximumNumberOfRequests)
         }
 
@@ -186,7 +186,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
 
         // then
         do {
-            let result = sut.enqueueRequest { .init(getFromPath: "/") }
+            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
             XCTAssertEqual(result, .success)
         }
     }
@@ -196,7 +196,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)
         sessionMock.nextCompletionParameters = (nil, response, nil)
         let completionExpectation = expectation(description: "Completion handler should be called")
-        let request = ZMTransportRequest(getFromPath: "/")
+        let request = ZMTransportRequest(getFromPath: "/", apiVersion: 0)
 
         request.add(ZMCompletionHandler(on: fakeUIContext) { response in
             // then
@@ -222,7 +222,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
 
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
         sessionMock.nextCompletionParameters = (nil, response, nil)
-        let request = ZMTransportRequest(getFromPath: "/")
+        let request = ZMTransportRequest(getFromPath: "/", apiVersion: 0)
 
         // when
         _ = sut.enqueueRequest { request }
@@ -235,7 +235,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         let response = URLResponse(url: url, mimeType: "", expectedContentLength: 1, textEncodingName: nil)
         sessionMock.nextCompletionParameters = (nil, response, NSError.requestExpiredError())
         let completionExpectation = expectation(description: "Completion handler should be called with errors")
-        let request = ZMTransportRequest(getFromPath: "/")
+        let request = ZMTransportRequest(getFromPath: "/", apiVersion: 0)
         
         request.add(ZMCompletionHandler(on: fakeUIContext) { response in
             // then

--- a/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
+++ b/Tests/Source/TransportSession/UnauthenticatedTransportSessionTests .swift
@@ -108,25 +108,25 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
     func testThatEnqueueOneTime_IncrementsTheRequestCounter() {
         // when
         (0..<3).forEach { _ in
-            sut.enqueueOneTime(.init(getFromPath: "/", apiVersion: 0))
+            sut.enqueueOneTime(.init(getFromPath: "/", apiVersion: .v0))
         }
         
         // then
-        let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
+        let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: .v0) }
         XCTAssertEqual(result, .maximumNumberOfRequests)
     }
     
     func testThatEnqueueOneTime_IsNotLimitedByRequestLimit() {
         // given
         (0..<3).forEach { _ in
-            sut.enqueueOneTime(.init(getFromPath: "/", apiVersion: 0))
+            sut.enqueueOneTime(.init(getFromPath: "/", apiVersion: .v0))
         }
         
         let task = MockTask()
         sessionMock.nextMockTask = task
         
         // when
-        sut.enqueueOneTime(.init(getFromPath: "/", apiVersion: 0))
+        sut.enqueueOneTime(.init(getFromPath: "/", apiVersion: .v0))
         
         // then
         XCTAssertEqual(task.resumeCallCount, 1)
@@ -138,7 +138,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         sessionMock.nextMockTask = task
 
         // when
-        let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
+        let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: .v0) }
 
         // then
         XCTAssertEqual(result, .success)
@@ -156,19 +156,19 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
     func testThatItDoesNotEnqueueMoreThanThreeRequests() {
         // when
         (0..<3).forEach { _ in
-            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
+            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: .v0) }
             XCTAssertEqual(result, .success)
         }
 
         // then
-        let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
+        let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: .v0) }
         XCTAssertEqual(result, .maximumNumberOfRequests)
     }
 
     func testThatItDoesEnqueueAnotherRequestAfterTheLastOneHasBeenCompleted() {
         // when
         (0..<3).forEach { _ in
-            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
+            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: .v0) }
             XCTAssertEqual(result, .success)
         }
 
@@ -176,7 +176,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
 
         // then
         do {
-            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
+            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: .v0) }
             XCTAssertEqual(result, .maximumNumberOfRequests)
         }
 
@@ -186,7 +186,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
 
         // then
         do {
-            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: 0) }
+            let result = sut.enqueueRequest { .init(getFromPath: "/", apiVersion: .v0) }
             XCTAssertEqual(result, .success)
         }
     }
@@ -196,7 +196,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: "HTTP/1.1", headerFields: nil)
         sessionMock.nextCompletionParameters = (nil, response, nil)
         let completionExpectation = expectation(description: "Completion handler should be called")
-        let request = ZMTransportRequest(getFromPath: "/", apiVersion: 0)
+        let request = ZMTransportRequest(getFromPath: "/", apiVersion: .v0)
 
         request.add(ZMCompletionHandler(on: fakeUIContext) { response in
             // then
@@ -222,7 +222,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
 
         let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)
         sessionMock.nextCompletionParameters = (nil, response, nil)
-        let request = ZMTransportRequest(getFromPath: "/", apiVersion: 0)
+        let request = ZMTransportRequest(getFromPath: "/", apiVersion: .v0)
 
         // when
         _ = sut.enqueueRequest { request }
@@ -235,7 +235,7 @@ final class UnauthenticatedTransportSessionTests: ZMTBaseTest {
         let response = URLResponse(url: url, mimeType: "", expectedContentLength: 1, textEncodingName: nil)
         sessionMock.nextCompletionParameters = (nil, response, NSError.requestExpiredError())
         let completionExpectation = expectation(description: "Completion handler should be called with errors")
-        let request = ZMTransportRequest(getFromPath: "/", apiVersion: 0)
+        let request = ZMTransportRequest(getFromPath: "/", apiVersion: .v0)
         
         request.add(ZMCompletionHandler(on: fakeUIContext) { response in
             // then

--- a/Tests/Source/TransportSession/ZMTransportSessionTests.m
+++ b/Tests/Source/TransportSession/ZMTransportSessionTests.m
@@ -562,7 +562,7 @@ static XCTestCase *currentTestCase;
         return [TestResponse testResponse];
     }];
     
-    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:path method:ZMMethodGET payload:nil];
+    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:path method:ZMMethodGET payload:nil apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED){
         [expectation fulfill];
@@ -579,7 +579,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatItEnqueuesSearchRequests;
 {
     // given
-    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:@"foo" method:ZMMethodGET payload:nil];
+    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:@"foo" method:ZMMethodGET payload:nil apiVersion:0];
     
     // when
     [self.sut enqueueOneTimeRequest:request];
@@ -593,7 +593,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatItEnqueuesRequests;
 {
     // given
-    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:@"foo" method:ZMMethodGET payload:nil];
+    ZMTransportRequest *request =[ZMTransportRequest requestWithPath:@"foo" method:ZMMethodGET payload:nil apiVersion:0];
     
     // when
     [self.sut attemptToEnqueueSyncRequestWithGenerator:^(){
@@ -629,7 +629,7 @@ static XCTestCase *currentTestCase;
         }];
 
         // when
-        ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:method payload:payload];
+        ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:method payload:payload apiVersion:0];
         [self.sut sendSchedulerItem:request];
         WaitForAllGroupsToBeEmpty(0.5);
         
@@ -651,7 +651,7 @@ static XCTestCase *currentTestCase;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPOST payload:@{}];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPOST payload:@{} apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         [expectation fulfill];
@@ -676,7 +676,7 @@ static XCTestCase *currentTestCase;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
     
     // when
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         [expectation fulfill];
@@ -701,7 +701,7 @@ static XCTestCase *currentTestCase;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest imageGetRequestFromPath:self.dummyPath];
+    ZMTransportRequest *request = [ZMTransportRequest imageGetRequestFromPath:self.dummyPath apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         [expectation fulfill];
@@ -738,7 +738,7 @@ static XCTestCase *currentTestCase;
     }];
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPOST payload:payload];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPOST payload:payload apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         [expectation fulfill];
@@ -781,7 +781,7 @@ static XCTestCase *currentTestCase;
     [[[(id)foregroundSession reject] andReturn:nil] taskWithRequest:OCMOCK_ANY bodyData:OCMOCK_ANY transportRequest:OCMOCK_ANY];
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPOST payload:payload];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPOST payload:payload apiVersion:0];
     [request forceToBackgroundSession];
     [sut sendSchedulerItem:request];
     
@@ -801,7 +801,7 @@ static XCTestCase *currentTestCase;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
     
     // when
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         [expectation fulfill];
@@ -828,7 +828,7 @@ static XCTestCase *currentTestCase;
     // when
     __block id<ZMTransportData> receivedPayload;
     
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         receivedPayload = response.payload;
@@ -858,7 +858,7 @@ static XCTestCase *currentTestCase;
     }];
     NSData *binaryData = [@"foo" dataUsingEncoding:NSUTF8StringEncoding];
     NSDictionary *contentDisposition = @{@"conv_id": @"912c7fc66cfb", @"width": @2};
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodPOST binaryData:binaryData type:(__bridge NSString *) kUTTypeJPEG contentDisposition:contentDisposition];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodPOST binaryData:binaryData type:(__bridge NSString *) kUTTypeJPEG contentDisposition:contentDisposition apiVersion:0];
     __block id<ZMTransportData> receivedPayload;
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
@@ -888,7 +888,7 @@ static XCTestCase *currentTestCase;
 
     // when
     __block NSInteger receivedStatusCode;
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         receivedStatusCode = response.HTTPStatus;
@@ -928,7 +928,7 @@ static XCTestCase *currentTestCase;
     
     // when
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
         return request;
     };
     
@@ -965,7 +965,7 @@ static XCTestCase *currentTestCase;
     
     // when
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
         return request;
     };
     
@@ -984,7 +984,7 @@ static XCTestCase *currentTestCase;
     
     // when
     ZMTransportEnqueueResult *result = [self.sut attemptToEnqueueSyncRequestWithGenerator:^(){
-        return [ZMTransportRequest requestGetFromPath:@"/foo"];
+        return [ZMTransportRequest requestGetFromPath:@"/foo" apiVersion:0];
     }];
     
     // then
@@ -1002,7 +1002,7 @@ static XCTestCase *currentTestCase;
     // when
     for (int i = 0; i < 20; ++i) {
         [self.sut attemptToEnqueueSyncRequestWithGenerator:^(){
-            return [ZMTransportRequest requestGetFromPath:@"/foo"];
+            return [ZMTransportRequest requestGetFromPath:@"/foo" apiVersion:0];
         }];
     }
     WaitForAllGroupsToBeEmpty(0.5);
@@ -1018,7 +1018,7 @@ static XCTestCase *currentTestCase;
     
     // when
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+        ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
         [request addCompletionHandler:
          [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         }]];
@@ -1042,7 +1042,7 @@ static XCTestCase *currentTestCase;
     // when
     for(int i = 0; i < maxRequests + 1; ++i) {
         ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-            ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+            ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
             [request addCompletionHandler:
              [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
             }]];
@@ -1108,7 +1108,7 @@ static XCTestCase *currentTestCase;
     for (int i = 0; i < (maxRequests + 1); ++i) {
         NSString *path = [NSString stringWithFormat:@"/A/%d", i];
         ZMTransportEnqueueResult *result = [self.sut attemptToEnqueueSyncRequestWithGenerator:^(){
-            ZMTransportRequest *r = [[ZMTransportRequest alloc] initWithPath:path method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+            ZMTransportRequest *r = [[ZMTransportRequest alloc] initWithPath:path method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
             [r addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeUIContext block:^(ZMTransportResponse * ZM_UNUSED response) {
             }]];
             return r;
@@ -1140,7 +1140,7 @@ static XCTestCase *currentTestCase;
     
     {
         ZMTransportEnqueueResult *result = [self.sut attemptToEnqueueSyncRequestWithGenerator:^(){
-            ZMTransportRequest *r = [[ZMTransportRequest alloc] initWithPath:@"/B" method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+            ZMTransportRequest *r = [[ZMTransportRequest alloc] initWithPath:@"/B" method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
             return r;
         }];
         WaitForAllGroupsToBeEmpty(0.5);
@@ -1171,7 +1171,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatARequestsThatNeedAuthenticationGeneratesAuthenticationHeaders
 {
     // given
-    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNeedsAccess];
+    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0];
     
     self.sut.accessToken = [[ZMAccessToken alloc] initWithToken:@"token-213" type:@"tokentype" expiresInSeconds:100000];
     
@@ -1195,7 +1195,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatARequestsThatDoesNotNeedAuthenticationDoesNotGenerateAuthenticationHeaders
 {
     // given
-    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     
     self.sut.accessToken = [[ZMAccessToken alloc] initWithToken:@"token-213" type:@"tokentype" expiresInSeconds:100000];
     
@@ -1217,7 +1217,7 @@ static XCTestCase *currentTestCase;
 - (void)testThatARequestThatCreatesAnAccessTokenDoesNotGenerateAuthenticationHeaders
 {
     // given
-    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken];
+    ZMTransportRequest *transportRequest = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0];
     
     self.sut.accessToken = [[ZMAccessToken alloc] initWithToken:@"token-213" type:@"tokentype" expiresInSeconds:100000];
     
@@ -1240,7 +1240,7 @@ static XCTestCase *currentTestCase;
 {
     // given
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodPOST payload:nil authentication:ZMTransportRequestAuthNone];
+        return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodPOST payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     };
     
     // then
@@ -1252,7 +1252,7 @@ static XCTestCase *currentTestCase;
 {
     // given
     ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-        return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodPUT payload:@[@34] authentication:ZMTransportRequestAuthNone];
+        return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodPUT payload:@[@34] authentication:ZMTransportRequestAuthNone apiVersion:0];
     };
     
     // then
@@ -1269,7 +1269,7 @@ static XCTestCase *currentTestCase;
     for(size_t i = 0; i < size; ++i)
     {
         ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-            return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:methodsWithPayload[i] payload:@[@42] authentication:ZMTransportRequestAuthNone];
+            return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:methodsWithPayload[i] payload:@[@42] authentication:ZMTransportRequestAuthNone apiVersion:0];
         };
         
         // then
@@ -1286,7 +1286,7 @@ static XCTestCase *currentTestCase;
     for(size_t i = 0; i < size; ++i)
     {
         ZMTransportRequestGenerator generator = ^ZMTransportRequest*(void) {
-            return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:methodsWithoutPayload[i] payload:nil authentication:ZMTransportRequestAuthNone];
+            return [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:methodsWithoutPayload[i] payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
         };
         
         // then
@@ -1528,7 +1528,7 @@ static XCTestCase *currentTestCase;
     
     __block ZMTransportResponse *response;
     XCTestExpectation *requestCompletedExpectation = [self expectationWithDescription:@"request completed"];
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPUT payload:dummyPayload];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodPUT payload:dummyPayload apiVersion:0];
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *r) {
         response = r;
         [requestCompletedExpectation fulfill];
@@ -1558,7 +1558,7 @@ static XCTestCase *currentTestCase;
     }];
     
     // when
-    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken];
+    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0];
     
     [self.sut sendSchedulerItem:request];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -1584,7 +1584,7 @@ static XCTestCase *currentTestCase;
     }];
     
     // when
-    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNeedsAccess];
+    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNeedsAccess apiVersion:0];
     
     [self.sut sendSchedulerItem:request];
     WaitForAllGroupsToBeEmpty(0.5);
@@ -1611,7 +1611,7 @@ static XCTestCase *currentTestCase;
     
     // when
     XCTestExpectation *didRun = [self expectationWithDescription:@"completion handler"];
-    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken];
+    ZMTransportRequest *request =  [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0];
     ZMPersistentCookieStorage *cookieStorage = self.sut.cookieStorage;
     [request addCompletionHandler:[ZMCompletionHandler handlerOnGroupQueue:self.fakeUIContext block:^(ZMTransportResponse * ZM_UNUSED r) {
         XCTAssertNotNil(cookieStorage.authenticationCookieData);
@@ -1729,7 +1729,7 @@ static XCTestCase *currentTestCase;
     }];
     WaitForAllGroupsToBeEmpty(0.5);
     
-    [self.sut sendSchedulerItem:[[ZMTransportRequest alloc] initWithPath:path method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken]];
+    [self.sut sendSchedulerItem:[[ZMTransportRequest alloc] initWithPath:path method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthCreatesCookieAndAccessToken apiVersion:0]];
     WaitForAllGroupsToBeEmpty(0.5);
     
     // after
@@ -1761,7 +1761,7 @@ static XCTestCase *currentTestCase;
     XCTestExpectation *expectation = [self expectationWithDescription:@"Completion handler called"];
     
     // when
-    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone];
+    ZMTransportRequest *request = [[ZMTransportRequest alloc] initWithPath:self.dummyPath method:ZMMethodGET payload:nil authentication:ZMTransportRequestAuthNone apiVersion:0];
     [request addCompletionHandler:
      [ZMCompletionHandler handlerOnGroupQueue:self.fakeSyncContext block:^(ZMTransportResponse *response ZM_UNUSED) {
         XCTAssertEqualObjects(response.imageData, jpegData);
@@ -1795,7 +1795,7 @@ static XCTestCase *currentTestCase;
     }] cancelTaskWithIdentifier:dataTask.taskIdentifier completionHandler:OCMOCK_ANY]; //this is the important part
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/foo"];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/foo" apiVersion:0];
     [request expireAfterInterval:0.2];
 
     [self.sut sendSchedulerItem:request];
@@ -1840,7 +1840,7 @@ static XCTestCase *currentTestCase;
 
 - (NSURLSessionTask *)suspendedTaskForBackgroundSession:(BOOL)backgroundSession applicationInBackground:(BOOL)applicationInBackground
 {
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/foo"];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/foo" apiVersion:0];
     
     if (applicationInBackground) {
         [self.sut enterBackground];
@@ -1888,7 +1888,7 @@ static XCTestCase *currentTestCase;
     [[(id) self.URLSession expect] setTimeoutTimer:ZM_ARG_SAVE(timer) forTask:task];
     
     // when
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/foo"];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/foo" apiVersion:0];
     [request expireAfterInterval:0.5];
     
     [request addCompletionHandler:
@@ -2045,7 +2045,7 @@ static XCTestCase *currentTestCase;
     // given
     self.sut.accessToken = self.validAccessToken;
     self.reachability.mayBeReachable = YES;
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodGET payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodGET payload:nil apiVersion:0];
     
     // expect
     XCTestExpectation *didComplete = [self expectationWithDescription:@"did complete response"];
@@ -2085,7 +2085,7 @@ static XCTestCase *currentTestCase;
     // given
     self.sut.accessToken = self.validAccessToken;
     self.reachability.mayBeReachable = YES;
-    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodGET payload:nil];
+    ZMTransportRequest *request = [ZMTransportRequest requestWithPath:self.dummyPath method:ZMMethodGET payload:nil apiVersion:0];
     
     // expect
     XCTestExpectation *didComplete = [self expectationWithDescription:@"did complete response"];
@@ -2351,8 +2351,8 @@ static XCTestCase *currentTestCase;
 {
     // given
     XCTestExpectation *expectation = [self expectationWithDescription:@"It should get the resumed background session tasks"];
-    ZMTransportRequest *foregroundRequest = [ZMTransportRequest requestGetFromPath:@"/some/path/foreground"];
-    ZMTransportRequest *backgroundRequest = [ZMTransportRequest requestGetFromPath:@"/some/path/background"];
+    ZMTransportRequest *foregroundRequest = [ZMTransportRequest requestGetFromPath:@"/some/path/foreground" apiVersion:0];
+    ZMTransportRequest *backgroundRequest = [ZMTransportRequest requestGetFromPath:@"/some/path/background" apiVersion:0];
     
     // expect
     NSURLSessionTask *expectedTask = [NSURLSessionTask new];
@@ -2421,7 +2421,7 @@ static XCTestCase *currentTestCase;
     __block ZMTransportResponse *receivedResponse;
         
     // when
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/foo"];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/foo" apiVersion:0];
     [request expireAfterInterval:0];
     
     [request addCompletionHandler:
@@ -2456,7 +2456,7 @@ static XCTestCase *currentTestCase;
         callbackReceived = YES;
         XCTAssertEqualObjects(receivedPath, expectedPath);
     };
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:expectedPath];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:expectedPath apiVersion:0];
     
     // when
     for(int i = 0; i < 30; ++i) {
@@ -2483,7 +2483,7 @@ static XCTestCase *currentTestCase;
         callbackReceived = YES;
         XCTAssertEqualObjects(receivedPath, expectedPath);
     };
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:expectedPath];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:expectedPath apiVersion:0];
     
     // when
     for(int i = 0; i < 2; ++i) {

--- a/Tests/Source/URLSession/ZMURLSessionTests.m
+++ b/Tests/Source/URLSession/ZMURLSessionTests.m
@@ -151,7 +151,7 @@ static NSString * const DataKey = @"data";
 - (void)testThatItPassesTheRequestToTheCompletionMethod;
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/some/path/"];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/some/path/" apiVersion:0];
     NSURLSessionTask *task = [self.sut taskWithRequest:self.URLRequestA bodyData:nil transportRequest:request];
     
     // when
@@ -269,7 +269,7 @@ static NSString * const DataKey = @"data";
     // given
     XCTestExpectation *expectation = [self expectationWithDescription:@"It should call the completionHandler"];
     
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/some/path/"];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"/some/path/" apiVersion:0];
     NSURLSessionTask *task = [self.sut taskWithRequest:self.URLRequestA bodyData:nil transportRequest:request];
     configurationBlock(task);
     
@@ -369,7 +369,7 @@ static NSString * const DataKey = @"data";
     NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@"foo"] statusCode:302 HTTPVersion:@"1.1" headerFields:@{}];
     
     // when
-    ZMTransportRequest *fakeRequest = [ZMTransportRequest requestGetFromPath:@"foo"];
+    ZMTransportRequest *fakeRequest = [ZMTransportRequest requestGetFromPath:@"foo" apiVersion:0];
     fakeRequest.doesNotFollowRedirects = YES;
     [self.sut setRequest:fakeRequest forTask:originalTask];
     
@@ -458,7 +458,7 @@ willPerformHTTPRedirection:response
                                                    verifyBlock:(void (^)(ZMTransportResponse *response))verifyBlock
 {
     // given
-    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"www.example.com"];
+    ZMTransportRequest *request = [ZMTransportRequest requestGetFromPath:@"www.example.com" apiVersion:0];
     request.shouldFailInsteadOfRetry = shouldFailInsteadOfRetry;
     
     __block ZMTransportResponse *receivedResponse;
@@ -659,7 +659,7 @@ willPerformHTTPRedirection:response
     NSString *path = @"https://baz.example.com/1/";
     NSURLRequest *request = [NSURLRequest requestWithURL:[NSURL URLWithString:path]];
     NSString *contentType = @"multipart/mixed; boundary=frontier";
-    ZMTransportRequest *transportRequest = [ZMTransportRequest uploadRequestWithFileURL:self.uniqueFileURL path:path contentType:contentType];
+    ZMTransportRequest *transportRequest = [ZMTransportRequest uploadRequestWithFileURL:self.uniqueFileURL path:path contentType:contentType apiVersion:0];
     WaitForAllGroupsToBeEmpty(0.5);
     [self spinMainQueueWithTimeout:0.1];
 

--- a/WireTransport.xcodeproj/project.pbxproj
+++ b/WireTransport.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		BFC6403C1D2CFE3300886274 /* ZMTransportRequest+AssetGet.h in Headers */ = {isa = PBXBuildFile; fileRef = BFC6403B1D2CFE3300886274 /* ZMTransportRequest+AssetGet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		BFEC39671CC6423700591F36 /* ZMTaskIdentifierTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BFEC39661CC6423700591F36 /* ZMTaskIdentifierTests.m */; };
 		CE3677691D48B4BA00A8015A /* BackgroundActivityFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE3677681D48B4BA00A8015A /* BackgroundActivityFactory.swift */; };
+		EE34565C27C92D5A008FC9E0 /* ZMAPIVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = EE34565B27C92D48008FC9E0 /* ZMAPIVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EF1A09A41FF6AC7500F89634 /* ZMPersistentCookieStorage+Testing.h in Headers */ = {isa = PBXBuildFile; fileRef = EF1A09A31FF6A73200F89634 /* ZMPersistentCookieStorage+Testing.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		F108BCC821C3CB6D00E1BBE3 /* Backend.bundle in Resources */ = {isa = PBXBuildFile; fileRef = F108BCC721C3CB6C00E1BBE3 /* Backend.bundle */; };
 		F118CBBF1F432F25004DCF96 /* ZMTransportSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F118CBBC1F432E75004DCF96 /* ZMTransportSessionTests.swift */; };
@@ -348,6 +349,7 @@
 		BFC6403B1D2CFE3300886274 /* ZMTransportRequest+AssetGet.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ZMTransportRequest+AssetGet.h"; sourceTree = "<group>"; };
 		BFEC39661CC6423700591F36 /* ZMTaskIdentifierTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZMTaskIdentifierTests.m; sourceTree = "<group>"; };
 		CE3677681D48B4BA00A8015A /* BackgroundActivityFactory.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BackgroundActivityFactory.swift; sourceTree = "<group>"; };
+		EE34565B27C92D48008FC9E0 /* ZMAPIVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZMAPIVersion.h; sourceTree = "<group>"; };
 		EF1A09A31FF6A73200F89634 /* ZMPersistentCookieStorage+Testing.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ZMPersistentCookieStorage+Testing.h"; sourceTree = "<group>"; };
 		EF1A09A51FF6BEE300F89634 /* testing.modulemap */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.module-map"; path = testing.modulemap; sourceTree = "<group>"; };
 		F108BCC721C3CB6C00E1BBE3 /* Backend.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; path = Backend.bundle; sourceTree = "<group>"; };
@@ -452,7 +454,9 @@
 				3E88BDE01B1F44FB00232589 /* Frameworks */,
 				3E88BCA81B1F35DF00232589 /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		3E88BCA81B1F35DF00232589 /* Products */ = {
 			isa = PBXGroup;
@@ -688,6 +692,7 @@
 		54CA150D1B32F2C1008D3787 /* Public */ = {
 			isa = PBXGroup;
 			children = (
+				EE34565B27C92D48008FC9E0 /* ZMAPIVersion.h */,
 				F1A522F52040264D009414E7 /* ZMUpdateEvent.swift */,
 				54CA15DE1B32F791008D3787 /* WireTransport.h */,
 				F1858A83226874C300FA2ACE /* Logging.swift */,
@@ -834,6 +839,7 @@
 				5499FFD01B31C66D00835C8B /* ZMTransportPushChannel.h in Headers */,
 				5499FFDC1B31C66D00835C8B /* ZMWebSocketHandshake.h in Headers */,
 				5499FFD41B31C66D00835C8B /* ZMWebSocket.h in Headers */,
+				EE34565C27C92D5A008FC9E0 /* ZMAPIVersion.h in Headers */,
 				161E04B42656C5FB00DADC3D /* ZMPushChannelType.h in Headers */,
 				BF453F1A1CC6377200403E1C /* ZMRequestCancellation.h in Headers */,
 				160C31231E5B28A10012E4BC /* ZMPushChannel.h in Headers */,


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-481" title="FS-481" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-481</a>  [iOS] Pair requests and responses with api version
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

With API versioning, all requests are made to a versioned endpoint. In order to correctly process the response of a versioned request, we must also be able to identify the api version of the response.

This PR adds an api version property to both `ZMTransportRequest` and `ZMTransportResponse`.

### Testing

No new tests have been added, but an assertion is made that when a request is completed with a response, the api versions must match.

### Notes 

For now we only consider that there exists version 0. In later work, we will start to support additional versions.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
