### PR TITLE
feat: add api version v1 FS-451

### DIFF
--- a/Source/Public/APIVersion.swift
+++ b/Source/Public/APIVersion.swift
@@ -27,6 +27,7 @@ import Foundation
 @objc
 public enum APIVersion: Int32 {
     case v0 = 0
+    case v1 = 1
 }
 
 // MARK: - CaseIterable

--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -524,7 +524,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 - (void)completeWithResponse:(ZMTransportResponse *)response
 {
-    RequireString(response.apiVersion == self.apiVersion, "Completed request and response should have matching api versions. Request has: %d Response has: %ld", response.apiVersion, (long)self.apiVersion);
+    RequireString(response.apiVersion == self.apiVersion, "Completed request and response should have matching api versions. Request has: %ld Response has: %d", (long)self.apiVersion, response.apiVersion);
     response.startOfUploadTimestamp = self.startOfUploadTimestamp;
 
     ZMSDispatchGroup *group = response.dispatchGroup;

--- a/Source/Requests/ZMTransportResponse.m
+++ b/Source/Requests/ZMTransportResponse.m
@@ -75,16 +75,16 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
 
 - (instancetype)initWithImageData:(NSData *)imageData HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(int)apiVersion;
 {
-    return [self initWithImageData:imageData payload:nil HTTPStatus:status networkError:error headers:headers];
+    return [self initWithImageData:imageData payload:nil HTTPStatus:status networkError:error headers:headers apiVersion:apiVersion];
 }
 
 
 - (instancetype)initWithPayload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status transportSessionError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(int)apiVersion;
 {
-    return [self initWithImageData:nil payload:payload HTTPStatus:status networkError:error headers:headers];
+    return [self initWithImageData:nil payload:payload HTTPStatus:status networkError:error headers:headers apiVersion:apiVersion];
 }
 
-- (instancetype)initWithImageData:(NSData *)imageData payload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status networkError:(NSError *)error headers:(NSDictionary *)headers
+- (instancetype)initWithImageData:(NSData *)imageData payload:(id<ZMTransportData>)payload HTTPStatus:(NSInteger)status networkError:(NSError *)error headers:(NSDictionary *)headers apiVersion:(int)apiVersion
 {
     self = [super init];
     if(self) {
@@ -94,7 +94,8 @@ static NSString* ZMLogTag ZM_UNUSED = ZMT_LOG_TAG_NETWORK;
         _imageData = [imageData copy];
         _HTTPStatus = status;
         _headers = headers;
-        
+        _apiVersion = apiVersion;
+
         self.rawResponse = [[NSHTTPURLResponse alloc] initWithURL:[NSURL URLWithString:@""] statusCode:status HTTPVersion:@"HTTP/1.1" headerFields:headers];
         self.rawData = self.imageData ?: [ZMTransportCodec encodedTransportData:self.payload];
     }


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-451" title="FS-451" target="_blank"><img alt="Sub-task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10816?size=medium" />FS-451</a>  [iOS] Use the common version for all API calls
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

This PR adds api version 1, which is designates the federation endpoints as being available.

### Notes

I added two small fixes in here too:
- the api version wasn't actually being stored in the transport responses.
- an error message had placeholder values incorrectly swapped.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [x] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
