### PR TITLE
chore(mls): added init method to accept header values FS-965

### DIFF
--- a/Source/Public/ZMTransportRequest.h
+++ b/Source/Public/ZMTransportRequest.h
@@ -107,8 +107,10 @@ typedef NS_ENUM(int8_t, ZMTransportAccept) {
 /// @link https://en.wikipedia.org/wiki/Uniform_Type_Identifier @/link
 /// @link https://developer.apple.com/library/ios/documentation/General/Conceptual/DevPedia-CocoaCore/UniformTypeIdentifier.html @/link
 - (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type contentDisposition:(nullable NSDictionary *)contentDisposition apiVersion:(int)apiVersion;
+
 - (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type contentDisposition:(nullable NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
 
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(nullable NSData *)data type:(nullable NSString *)type acceptHeaderType:(ZMTransportAccept)acceptHeaderType contentDisposition:(nullable NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
 
 @property (nonatomic, readonly) NSString *methodAsString;
 @property (nonatomic, readonly, copy, nullable) id<ZMTransportData> payload;

--- a/Source/Requests/ZMTransportRequest.m
+++ b/Source/Requests/ZMTransportRequest.m
@@ -247,6 +247,11 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
 
 - (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(NSData *)data type:(NSString *)type contentDisposition:(NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
 {
+    return [self initWithPath:path method:method binaryData:data type:type acceptHeaderType:ZMTransportAcceptTransportData contentDisposition:contentDisposition shouldCompress:NO apiVersion:apiVersion];
+}
+
+- (instancetype)initWithPath:(NSString *)path method:(ZMTransportRequestMethod)method binaryData:(NSData *)data type:(NSString *)type acceptHeaderType:(ZMTransportAccept)acceptHeaderType contentDisposition:(NSDictionary *)contentDisposition shouldCompress:(BOOL)shouldCompress apiVersion:(int)apiVersion;
+{
     self = [super init];
     if (self != nil) {
         self.path = apiVersion == 0 ? path : [NSString stringWithFormat:@"/v%d%@", apiVersion, path];
@@ -256,7 +261,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
         self.contentDisposition = contentDisposition;
         self.needsAuthentication = YES;
         self.responseWillContainAccessToken = NO;
-        self.acceptedResponseMediaTypes = ZMTransportAcceptTransportData;
+        self.acceptedResponseMediaTypes = acceptHeaderType;
         self.shouldCompress = shouldCompress;
         self.debugInformation = [NSMutableArray array];
         self.contentDebugInformationHash = data.hash;
@@ -498,7 +503,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
                 [handlerGroup leave];
             }];
         }
-    }    
+    }
 }
 
 - (void)addCompletionHandler:(ZMCompletionHandler *)completionHandler;
@@ -541,7 +546,7 @@ typedef NS_ENUM(NSUInteger, ZMTransportRequestSessionType) {
                                    self.methodAsString,
                                    self.path,
                                    @(response.HTTPStatus)
-                                   ];
+                ];
                 ZMSTimePoint *tp = [ZMSTimePoint timePointWithInterval:6 label:label];
                 handler.block(response);
                 [tp warnIfLongerThanInterval];


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-965" title="FS-965" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-965</a>  [iOS] Refactor `ZMTransportRequest` to allow setting Accept header values externally
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

- We need a way to be able to set the “accept” header when initialising a `ZMTransportRequest`.

### Solutions

- Added a new initialiser `ZMTransportRequest` that accepts the header type.

----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [ ] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
