### PR TITLE
fix: newly logged in client gets logged out FS-1343

### DIFF
--- a/Source/Public/ZMPersistentCookieStorage+Label.swift
+++ b/Source/Public/ZMPersistentCookieStorage+Label.swift
@@ -33,7 +33,7 @@ import UIKit
     }
 
     private override convenience init() {
-        self.init(value: UIDevice.current.identifierForVendor?.uuidString ?? UUID().uuidString)
+        self.init(value: UUID().uuidString)
     }
 
     public var length: Int {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://wearezeta.atlassian.net/browse/FS-1343" title="FS-1343" target="_blank"><img alt="Task" src="https://wearezeta.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10818?size=medium" />FS-1343</a>  [iOS] Newly logged in client gets logged out
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
<!--do not remove this marker, its needed to replace info when ticket title is updated -->

----
#### PR Submission Checklist for internal contributors

- The **PR Title**
  - [x] conforms to the style of semantic commits messages¹ supported in Wire's Github Workflow²
  - [x] contains a reference JIRA issue number like `SQPIT-764`
  - [x] answers the question: _If merged, this PR will: ..._ ³

- The **PR Description**
  - [x] is free of optional paragraphs and you have filled the relevant parts to the best of your ability
----

# What's new in this PR?

### Issues

Sometimes a logged in client can get logged out if another client from the same device and account is deleted.

### Causes 

When logging in with a new client, we push up a cookie label that is unique for the device and app. **It is neither unique across accounts nor clients from the same account on the same device**. When a client is deleted, its associated cookies are deleted too, i.e all cookies that have the same cookie label.

This means that if there are two clients with the same cookie label, then deleting one client will delete cookies for both clients. When the non-deleted client tries to use the cookie (its stored locally) to request a new access token, the backend will return an "invalid token" response and the app will handle this by deleting the local cookie and logging out the user.

### Solutions

Use a completely unique cookie label.


----
#### PR Post Submission Checklist for internal contributors (Optional)

 - [x] Wire's Github Workflow has automatically linked the PR to a JIRA issue
----
#### PR Post Merge Checklist for internal contributors

 - [ ] If any soft of configuration variable was introduced by this PR, it has been added to the relevant documents and the CI jobs have been updated.
----
##### References
1. https://sparkbox.com/foundry/semantic_commit_messages
1. https://github.com/wireapp/.github#usage
1. E.g. `feat(conversation-list): Sort conversations by most emojis in the title #SQPIT-764`.
